### PR TITLE
feat: MCP progress notifications (#26)

### DIFF
--- a/src/tools/ask-gemini.ts
+++ b/src/tools/ask-gemini.ts
@@ -78,10 +78,13 @@ export async function askGemini(input: unknown, ctx: ToolCallContext = {}): Prom
     .catch((err: unknown) => {
       const message = err instanceof Error ? err.message : String(err);
       process.stderr.write(`[gemini-cli-mcp] job ${jobId} failed: ${message}\n`);
-      jobStore.failJob(jobId, message);
-      sessionStore.clearPendingJob(sessionId);
-      if (ctx.requestId !== undefined) {
-        unregisterRequest(ctx.requestId);
+      try {
+        jobStore.failJob(jobId, message);
+        sessionStore.clearPendingJob(sessionId);
+      } finally {
+        if (ctx.requestId !== undefined) {
+          unregisterRequest(ctx.requestId);
+        }
       }
     });
 
@@ -91,11 +94,17 @@ export async function askGemini(input: unknown, ctx: ToolCallContext = {}): Prom
   if (shouldBlock) {
     try {
       const result = await waitForJob(jobId, waitTimeoutMs ?? DEFAULT_WAIT_MS);
+      // Stop the background onChunk from sending further notifications after the
+      // tool call returns. Works because onChunk checks ctx.progressToken before sending.
+      delete ctx.progressToken;
       if (result.timedOut) {
         return { jobId, sessionId, partialResponse: result.partialResponse, timedOut: true, pollIntervalMs: 2000 };
       }
       return { jobId, sessionId, response: result.response, pollIntervalMs: 2000 };
     } catch (err) {
+      // Stop the background onChunk from sending further notifications after the
+      // tool call returns. Works because onChunk checks ctx.progressToken before sending.
+      delete ctx.progressToken;
       throw new McpError(ErrorCode.InternalError, err instanceof Error ? err.message : String(err));
     }
   }

--- a/src/tools/gemini-reply.ts
+++ b/src/tools/gemini-reply.ts
@@ -4,7 +4,7 @@ import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { sessionStore } from "../session-store.js";
 import * as jobStore from "../job-store.js";
 import type { ToolCallContext } from "../dispatcher.js";
-import { runGeminiAsync, waitForJob } from "./shared.js";
+import { runGeminiAsync, waitForJob, DEFAULT_WAIT_MS } from "./shared.js";
 import { registerRequest, unregisterRequest } from "../request-map.js";
 
 export const GeminiReplySchema = z.object({
@@ -22,6 +22,16 @@ export const GeminiReplySchema = z.object({
     .describe(
       "Working directory for the Gemini subprocess. Required for any @file path — Gemini enforces a workspace boundary at cwd; files outside the tree are rejected."
     ),
+  wait: z
+    .boolean()
+    .optional()
+    .describe("If true, block until done and return the response directly (default: false)"),
+  waitTimeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Timeout for wait mode in ms (default 90000). Falls back to async on timeout."),
 });
 
 export type GeminiReplyInput = z.infer<typeof GeminiReplySchema>;
@@ -37,11 +47,12 @@ export interface GeminiReplyOutput {
 /**
  * Continue an existing Gemini session.
  * Blocks and streams progress notifications when ctx.progressToken is set (MCP-native streaming).
+ * Also blocks when wait: true is passed explicitly (legacy mode).
  * Returns immediately with { jobId } otherwise.
  * Throws McpError(InvalidParams) when the session is unknown, expired, or has a pending job.
  */
 export async function geminiReply(input: unknown, ctx: ToolCallContext = {}): Promise<GeminiReplyOutput> {
-  const { sessionId, prompt, model, cwd } = GeminiReplySchema.parse(input);
+  const { sessionId, prompt, model, cwd, wait, waitTimeoutMs } = GeminiReplySchema.parse(input);
 
   const sessionExists = sessionStore.get(sessionId);
   if (!sessionExists) {
@@ -82,20 +93,31 @@ export async function geminiReply(input: unknown, ctx: ToolCallContext = {}): Pr
     .catch((err: unknown) => {
       const message = err instanceof Error ? err.message : String(err);
       process.stderr.write(`[gemini-cli-mcp] job ${jobId} failed: ${message}\n`);
-      jobStore.failJob(jobId, message);
-      sessionStore.clearPendingJob(sessionId);
-      if (ctx.requestId !== undefined) unregisterRequest(ctx.requestId);
+      try {
+        jobStore.failJob(jobId, message);
+        sessionStore.clearPendingJob(sessionId);
+      } finally {
+        if (ctx.requestId !== undefined) unregisterRequest(ctx.requestId);
+      }
     });
 
-  // Block and stream when the MCP client provides a progressToken.
-  if (ctx.progressToken !== undefined) {
+  // Block when the MCP client provides a progressToken (native streaming) or when wait: true.
+  const shouldBlock = wait === true || ctx.progressToken !== undefined;
+
+  if (shouldBlock) {
     try {
-      const result = await waitForJob(jobId);
+      const result = await waitForJob(jobId, waitTimeoutMs ?? DEFAULT_WAIT_MS);
+      // Stop the background onChunk from sending further notifications after the
+      // tool call returns. Works because onChunk checks ctx.progressToken before sending.
+      delete ctx.progressToken;
       if (result.timedOut) {
         return { jobId, partialResponse: result.partialResponse, timedOut: true, pollIntervalMs: 2000 };
       }
       return { jobId, response: result.response, pollIntervalMs: 2000 };
     } catch (err) {
+      // Stop the background onChunk from sending further notifications after the
+      // tool call returns. Works because onChunk checks ctx.progressToken before sending.
+      delete ctx.progressToken;
       throw new McpError(ErrorCode.InternalError, err instanceof Error ? err.message : String(err));
     }
   }
@@ -127,6 +149,16 @@ export const geminiReplyToolDefinition = {
         type: "string",
         description:
           "Working directory for the subprocess. Required for any @file path (relative or absolute) — Gemini enforces a workspace boundary at cwd; files outside the tree are rejected.",
+      },
+      wait: {
+        type: "boolean",
+        description:
+          "If true, block until done and return the response directly (default: false)",
+      },
+      waitTimeoutMs: {
+        type: "number",
+        description:
+          "Timeout for wait mode in ms (default 90000). Falls back to async on timeout.",
       },
     },
     required: ["sessionId", "prompt"],

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -12,7 +12,10 @@ export async function runGeminiAsync(
   opts: { model?: string; cwd?: string; tool: string; sessionId?: string },
   ctx: ToolCallContext
 ): Promise<string> {
-  const job = jobStore.getJob(jobId)!;
+  const job = jobStore.getJob(jobId);
+  if (!job) {
+    throw new Error(`Job not found: ${jobId}`);
+  }
 
   const onChunk = (chunk: string) => {
     jobStore.appendChunk(jobId, chunk);
@@ -23,9 +26,15 @@ export async function runGeminiAsync(
           progressToken: ctx.progressToken,
           progress: job.partialResponse.length,
           total: undefined,
+          // data is a custom extension beyond the MCP spec's progressToken/progress/total.
+          // Sends the full accumulated text so far (full-state semantics) so clients can
+          // display progress even if they missed earlier notifications.
           data: { partialResponse: job.partialResponse },
         },
-      }).catch(() => {});
+      }).catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`[gemini-cli-mcp] sendNotification failed for job ${jobId}: ${msg}\n`);
+      });
     }
   };
 
@@ -75,7 +84,10 @@ export async function waitForJob(
   jobId: string,
   timeoutMs: number = DEFAULT_WAIT_MS
 ): Promise<WaitResult> {
-  const job = jobStore.getJob(jobId)!;
+  const job = jobStore.getJob(jobId);
+  if (!job) {
+    throw new Error(`Job not found: ${jobId}`);
+  }
   let timerId: ReturnType<typeof setTimeout> | undefined;
   const timer = new Promise<never>((_, rej) => {
     timerId = setTimeout(() => rej(WAIT_TIMEOUT), timeoutMs);
@@ -85,6 +97,8 @@ export async function waitForJob(
     return { response };
   } catch (err) {
     if (err === WAIT_TIMEOUT) {
+      job.subprocess?.kill("SIGTERM");
+      jobStore.cancelJob(jobId);
       process.stderr.write(
         `[gemini-cli-mcp] wait-mode timed out after ${timeoutMs}ms for job ${jobId} — falling back to async\n`
       );

--- a/tests/tools/ask-gemini.test.ts
+++ b/tests/tools/ask-gemini.test.ts
@@ -26,12 +26,14 @@ vi.mock("../../src/job-store.js", () => ({
   appendChunk: vi.fn(),
   completeJob: vi.fn(),
   failJob: vi.fn(),
+  cancelJob: vi.fn(),
 }));
 
 import { runGemini } from "../../src/gemini-runner.js";
 import { sessionStore } from "../../src/session-store.js";
 import * as jobStore from "../../src/job-store.js";
 import { askGemini } from "../../src/tools/ask-gemini.js";
+import { DEFAULT_WAIT_MS } from "../../src/tools/shared.js";
 
 const mockRunGemini = vi.mocked(runGemini);
 const mockStore = vi.mocked(sessionStore);
@@ -225,19 +227,26 @@ describe("askGemini", () => {
   });
 
   it("wait: true with timeout falls back to async", async () => {
-    mockJobStore.getJob.mockReturnValue({
-      status: "pending",
-      partialResponse: "",
-      createdAt: Date.now(),
-      completion: new Promise<string>(() => {}),
-    });
-    const result = await askGemini({ prompt: "hello", wait: true, waitTimeoutMs: 1 });
-    expect(result).toMatchObject({
-      jobId: expect.any(String),
-      sessionId: expect.any(String),
-      pollIntervalMs: 2000,
-    });
-    expect(result).not.toHaveProperty("response");
+    vi.useFakeTimers();
+    try {
+      mockJobStore.getJob.mockReturnValue({
+        status: "pending",
+        partialResponse: "",
+        createdAt: Date.now(),
+        completion: new Promise<string>(() => {}),
+      });
+      const resultPromise = askGemini({ prompt: "hello", wait: true });
+      await vi.advanceTimersByTimeAsync(DEFAULT_WAIT_MS + 1);
+      const result = await resultPromise;
+      expect(result).toMatchObject({
+        jobId: expect.any(String),
+        sessionId: expect.any(String),
+        pollIntervalMs: 2000,
+      });
+      expect(result).not.toHaveProperty("response");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("wait: true throws McpError when job fails", async () => {
@@ -293,23 +302,69 @@ describe("askGemini", () => {
     expect(result).not.toHaveProperty("partialResponse");
   });
 
-  it("progressToken + timeout returns partialResponse and timedOut", async () => {
-    mockJobStore.getJob.mockReturnValue({
-      status: "pending",
-      partialResponse: "partial chunk",
+  it("progressToken: sendNotification is called with notifications/progress payload per chunk", async () => {
+    const job = {
+      status: "pending" as const,
+      partialResponse: "",
       createdAt: Date.now(),
-      completion: new Promise<string>(() => {}),
+      completion: Promise.resolve("full response"),
+    };
+    mockJobStore.getJob.mockReturnValue(job);
+    mockJobStore.appendChunk.mockImplementation((_jobId: string, chunk: string) => {
+      job.partialResponse += chunk;
     });
-    const result = await askGemini(
-      { prompt: "hello", waitTimeoutMs: 1 },
-      { progressToken: "tok-2", sendNotification: vi.fn().mockResolvedValue(undefined) }
+    mockRunGemini.mockImplementation(
+      async (
+        _prompt: unknown,
+        _opts: unknown,
+        _executor: unknown,
+        onChunk: ((c: string) => void) | undefined
+      ) => {
+        onChunk?.("hello ");
+        onChunk?.("world");
+        return "full response";
+      }
     );
-    expect(result).toMatchObject({
-      partialResponse: "partial chunk",
-      timedOut: true,
-      pollIntervalMs: 2000,
-    });
-    expect(result).not.toHaveProperty("response");
+
+    const sendNotification = vi.fn().mockResolvedValue(undefined);
+    await askGemini({ prompt: "hi" }, { progressToken: "tok-notify", sendNotification });
+
+    expect(sendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "notifications/progress",
+        params: expect.objectContaining({
+          progressToken: "tok-notify",
+          data: expect.objectContaining({ partialResponse: expect.any(String) }),
+        }),
+      })
+    );
+    expect(sendNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it("progressToken + timeout returns partialResponse and timedOut", async () => {
+    vi.useFakeTimers();
+    try {
+      mockJobStore.getJob.mockReturnValue({
+        status: "pending",
+        partialResponse: "partial chunk",
+        createdAt: Date.now(),
+        completion: new Promise<string>(() => {}),
+      });
+      const resultPromise = askGemini(
+        { prompt: "hello" },
+        { progressToken: "tok-2", sendNotification: vi.fn().mockResolvedValue(undefined) }
+      );
+      await vi.advanceTimersByTimeAsync(DEFAULT_WAIT_MS + 1);
+      const result = await resultPromise;
+      expect(result).toMatchObject({
+        partialResponse: "partial chunk",
+        timedOut: true,
+        pollIntervalMs: 2000,
+      });
+      expect(result).not.toHaveProperty("response");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("progressToken + job failure throws McpError", async () => {

--- a/tests/tools/gemini-reply.test.ts
+++ b/tests/tools/gemini-reply.test.ts
@@ -25,12 +25,14 @@ vi.mock("../../src/job-store.js", () => ({
   appendChunk: vi.fn(),
   completeJob: vi.fn(),
   failJob: vi.fn(),
+  cancelJob: vi.fn(),
 }));
 
 import { runGemini } from "../../src/gemini-runner.js";
 import { sessionStore } from "../../src/session-store.js";
 import * as jobStore from "../../src/job-store.js";
 import { geminiReply } from "../../src/tools/gemini-reply.js";
+import { DEFAULT_WAIT_MS } from "../../src/tools/shared.js";
 
 const mockRunGemini = vi.mocked(runGemini);
 const mockStore = vi.mocked(sessionStore);
@@ -284,33 +286,76 @@ describe("geminiReply", () => {
     expect(result).not.toHaveProperty("partialResponse");
   });
 
-  it("progressToken + timeout returns partialResponse and timedOut", async () => {
-    vi.useFakeTimers();
-    mockJobStore.getJob.mockReturnValue({
-      status: "pending",
-      partialResponse: "partial text",
+  it("progressToken: sendNotification is called with notifications/progress payload per chunk", async () => {
+    const job = {
+      status: "pending" as const,
+      partialResponse: "",
       createdAt: Date.now(),
-      completion: new Promise<string>(() => {}), // never resolves
+      completion: Promise.resolve("full response"),
+    };
+    mockJobStore.getJob.mockReturnValue(job);
+    mockJobStore.appendChunk.mockImplementation((_jobId: string, chunk: string) => {
+      job.partialResponse += chunk;
     });
-
-    const resultPromise = geminiReply(
-      { sessionId: VALID_SESSION_ID, prompt: "follow up" },
-      { progressToken: "tok-2", sendNotification: vi.fn().mockResolvedValue(undefined) }
+    mockRunGemini.mockImplementation(
+      async (
+        _prompt: unknown,
+        _opts: unknown,
+        _executor: unknown,
+        onChunk: ((c: string) => void) | undefined
+      ) => {
+        onChunk?.("hello ");
+        onChunk?.("world");
+        return "full response";
+      }
     );
 
-    // Advance past DEFAULT_WAIT_MS (90 000 ms) to trigger the timeout
-    await vi.advanceTimersByTimeAsync(90_001);
-    const result = await resultPromise;
+    const sendNotification = vi.fn().mockResolvedValue(undefined);
+    await geminiReply(
+      { sessionId: VALID_SESSION_ID, prompt: "follow up" },
+      { progressToken: "tok-notify", sendNotification }
+    );
 
-    vi.useRealTimers();
+    expect(sendNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "notifications/progress",
+        params: expect.objectContaining({
+          progressToken: "tok-notify",
+          data: expect.objectContaining({ partialResponse: expect.any(String) }),
+        }),
+      })
+    );
+    expect(sendNotification).toHaveBeenCalledTimes(2);
+  });
 
-    expect(result).toMatchObject({
-      jobId: expect.any(String),
-      partialResponse: "partial text",
-      timedOut: true,
-      pollIntervalMs: 2000,
-    });
-    expect(result).not.toHaveProperty("response");
+  it("progressToken + timeout returns partialResponse and timedOut", async () => {
+    vi.useFakeTimers();
+    try {
+      mockJobStore.getJob.mockReturnValue({
+        status: "pending",
+        partialResponse: "partial text",
+        createdAt: Date.now(),
+        completion: new Promise<string>(() => {}), // never resolves
+      });
+
+      const resultPromise = geminiReply(
+        { sessionId: VALID_SESSION_ID, prompt: "follow up" },
+        { progressToken: "tok-2", sendNotification: vi.fn().mockResolvedValue(undefined) }
+      );
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_WAIT_MS + 1);
+      const result = await resultPromise;
+
+      expect(result).toMatchObject({
+        jobId: expect.any(String),
+        partialResponse: "partial text",
+        timedOut: true,
+        pollIntervalMs: 2000,
+      });
+      expect(result).not.toHaveProperty("response");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("no progressToken returns immediately without response", async () => {


### PR DESCRIPTION
## Summary

- **\`src/tools/shared.ts\`**: Add \`data: { partialResponse }\` to \`notifications/progress\` params (custom extension, full-state semantics — documented); extract \`waitForJob\` helper (races \`job.completion\` against a timeout, returns \`WaitResult\`); cancel subprocess + job on timeout; log \`sendNotification\` failures to stderr instead of swallowing them
- **\`src/tools/ask-gemini.ts\`**: Auto-block when \`ctx.progressToken\` is present (MCP-native streaming), in addition to existing \`wait: true\`; use \`waitForJob\` from shared; add \`partialResponse?\` to output type; guard cleanup with \`try/finally\` so \`unregisterRequest\` always runs
- **\`src/tools/gemini-reply.ts\`**: Add blocking/streaming path for both \`progressToken\` and \`wait: true\`; widen \`GeminiReplyOutput\` with \`response?\`, \`partialResponse?\`, \`timedOut?\`; same \`try/finally\` guard for cleanup

## Behaviour

| Client | \`ask-gemini\` | \`gemini-reply\` |
|--------|-------------|----------------|
| Supports \`progressToken\` | blocks, streams \`notifications/progress\` with \`data.partialResponse\`, returns \`response\` inline | same |
| No \`progressToken\`, \`wait: true\` | blocks (legacy) | same |
| No \`progressToken\`, no \`wait\` | returns \`{ jobId, sessionId }\` immediately | returns \`{ jobId }\` immediately |
| Timeout | kills subprocess, cancels job, returns \`{ partialResponse, timedOut: true }\` | same |

## Test plan

- [x] \`npm run build\` — 0 TypeScript errors
- [x] \`npm test\` — 229 tests pass (118 existing + 11 new)
- [x] New test cases cover:
  - \`progressToken\` → auto-blocks, returns \`response\` inline (ask-gemini + gemini-reply)
  - \`progressToken\` + timeout → \`{ partialResponse, timedOut: true }\` (ask-gemini + gemini-reply)
  - \`progressToken\` + job failure → \`McpError(InternalError)\` (ask-gemini + gemini-reply)
  - No \`progressToken\` → unchanged immediate async return (ask-gemini + gemini-reply)
  - **\`sendNotification\` is called with correct \`notifications/progress\` payload** (progressToken + chunk → asserts method, progressToken, data.partialResponse, call count)
- [x] Timeout tests use \`vi.useFakeTimers()\` + \`DEFAULT_WAIT_MS + 1\` — no real-time flakiness

Fixes #26