### PR TITLE
fix: delay warm pool prompt write until CLI startup completes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 
 ## Build & test
 - `npm run build` — tsc (must pass before commit)
-- `npm test` — vitest (244 tests; all must pass)
+- `npm test` — vitest (263 tests; all must pass)
 - SQLite emits `ExperimentalWarning` in test output — not an error, safe to ignore
 
 ## Testing patterns
@@ -29,5 +29,8 @@
 | `GEMINI_STRUCTURED_LOGS` | `0` | `1` = JSON telemetry lines to stderr |
 | `GEMINI_MAX_HISTORY_TURNS` | `20` | History sliding window (turn-pairs; 0=unlimited) |
 | `GEMINI_SESSION_DB` | `~/.gemini-cli-mcp/sessions.db` | SQLite path; `:memory:` = ephemeral |
+| `GEMINI_CACHE_TTL_MS` | `300000` | Response cache TTL (ms); `0` = disabled |
+| `GEMINI_CACHE_MAX_ENTRIES` | `50` | Max entries in the response cache |
 | `GEMINI_POOL_ENABLED` | `1` | `0` = disable warm pool (cold spawn only, for debugging) |
 | `GEMINI_POOL_SIZE` | `GEMINI_MAX_CONCURRENT` | Number of pre-spawned warm processes |
+| `GEMINI_POOL_STARTUP_MS` | `12000` | Estimated CLI startup time (ms); prompt writes delayed until this age after spawn |

--- a/scripts/bench-pool.mjs
+++ b/scripts/bench-pool.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * Timing comparison: warm pool vs cold spawn.
+ *
+ * Runs N ask-gemini calls in each mode and reports P50 / P90 / min / max.
+ * Each mode runs in a separate subprocess so module-level singletons
+ * (warmPool, POOL_ENABLED) initialize correctly for that configuration.
+ */
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(join(__dirname, ".."));
+
+const SAMPLES = 3; // real Gemini calls — keep low to avoid rate-limit
+// Prompts must be unique per sample to defeat the response cache (300s TTL by default).
+// We also set GEMINI_CACHE_TTL_MS=0 in env, but unique prompts provide a belt-and-suspenders guard.
+const PROMPTS = Array.from({ length: SAMPLES }, (_, i) =>
+  `reply with the single word pong — sample ${i + 1} of ${SAMPLES} run ${Date.now()}`
+);
+
+// ── subprocess runner ────────────────────────────────────────────────────────
+
+function runBatch(label, env, n) {
+  const code = `
+import { handleCallTool } from "./dist/dispatcher.js";
+import { warmPool } from "./dist/gemini-runner.js";
+
+// Give pool time to fully pre-spawn before first request.
+// The Gemini CLI takes ~4-5 s to start, so we wait 8 s to ensure
+// the warm processes are sitting idle and ready before we measure.
+if (warmPool !== null) {
+  await new Promise(r => setTimeout(r, 8000));
+}
+
+const poolMode = warmPool !== null ? "warm" : "cold";
+const samples = [];
+const prompts = ${JSON.stringify(PROMPTS)};
+
+for (let i = 0; i < ${n}; i++) {
+  const t0 = Date.now();
+  const result = await handleCallTool("ask-gemini", {
+    prompt: prompts[i],
+    wait: true,
+    waitTimeoutMs: 120_000,
+  });
+  const ms = Date.now() - t0;
+  const ok = !result.isError;
+  samples.push({ i, ms, ok });
+  process.stderr.write(\`  sample \${i + 1}/${n}: \${ms} ms  ok=\${ok}\\n\`);
+}
+
+process.stdout.write(JSON.stringify({ poolMode, samples }) + "\\n");
+const anyFail = samples.some(s => !s.ok);
+process.exit(anyFail ? 1 : 0);
+`;
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", ["--input-type=module"], {
+      env: { ...process.env, ...env },
+      cwd: projectRoot,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    child.stdout.on("data", (d) => { stdout += d; });
+    child.stderr.on("data", (d) => { process.stderr.write(String(d)); });
+
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`[${label}] timed out`));
+    }, 600_000);
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      try {
+        const data = JSON.parse(stdout.trim().split("\n").pop());
+        resolve({ label, ...data, exitCode: code });
+      } catch {
+        reject(new Error(`[${label}] failed to parse output:\n${stdout}`));
+      }
+    });
+
+    child.stdin.end(code);
+  });
+}
+
+// ── stats helpers ────────────────────────────────────────────────────────────
+
+function stats(samples) {
+  const ms = samples.map(s => s.ms).sort((a, b) => a - b);
+  const p = (pct) => ms[Math.min(Math.floor(ms.length * pct / 100), ms.length - 1)];
+  return {
+    min: ms[0],
+    p50: p(50),
+    p90: p(90),
+    max: ms[ms.length - 1],
+    avg: Math.round(ms.reduce((a, b) => a + b, 0) / ms.length),
+  };
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+console.log(`Benchmark: warm pool vs cold spawn  (${SAMPLES} samples each, cache disabled)\n`);
+
+console.log(`── Cold spawn (GEMINI_POOL_ENABLED=0) ──`);
+const coldResult = await runBatch("cold", {
+  GEMINI_POOL_ENABLED: "0",
+  GEMINI_CACHE_TTL_MS: "0",
+  GEMINI_SESSION_DB: ":memory:",
+}, SAMPLES);
+const coldStats = stats(coldResult.samples);
+
+console.log(`\n── Warm pool (GEMINI_POOL_ENABLED=1) ──`);
+const warmResult = await runBatch("warm", {
+  GEMINI_POOL_ENABLED: "1",
+  GEMINI_CACHE_TTL_MS: "0",
+  GEMINI_SESSION_DB: ":memory:",
+}, SAMPLES);
+const warmStats = stats(warmResult.samples);
+
+// ── report ───────────────────────────────────────────────────────────────────
+
+const fmt = (n) => `${n} ms`;
+const delta = (cold, warm) => {
+  const diff = cold - warm;
+  const sign = diff >= 0 ? "-" : "+";
+  return `${sign}${Math.abs(diff)} ms (${sign}${Math.round(Math.abs(diff) / cold * 100)}%)`;
+};
+
+console.log(`
+${"═".repeat(60)}
+Results (${SAMPLES} samples each)
+${"─".repeat(60)}
+Metric      Cold spawn    Warm pool     Δ (cold→warm)
+${"─".repeat(60)}
+min         ${fmt(coldStats.min).padEnd(14)}${fmt(warmStats.min).padEnd(14)}${delta(coldStats.min, warmStats.min)}
+avg         ${fmt(coldStats.avg).padEnd(14)}${fmt(warmStats.avg).padEnd(14)}${delta(coldStats.avg, warmStats.avg)}
+p50         ${fmt(coldStats.p50).padEnd(14)}${fmt(warmStats.p50).padEnd(14)}${delta(coldStats.p50, warmStats.p50)}
+p90         ${fmt(coldStats.p90).padEnd(14)}${fmt(warmStats.p90).padEnd(14)}${delta(coldStats.p90, warmStats.p90)}
+max         ${fmt(coldStats.max).padEnd(14)}${fmt(warmStats.max).padEnd(14)}${delta(coldStats.max, warmStats.max)}
+${"─".repeat(60)}
+Cold samples: ${coldResult.samples.map(s => s.ms).join(", ")} ms
+Warm samples: ${warmResult.samples.map(s => s.ms).join(", ")} ms
+${"═".repeat(60)}
+`);

--- a/scripts/test-pool-manual.mjs
+++ b/scripts/test-pool-manual.mjs
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+/**
+ * Manual test runner for WarmProcessPool items 3–6 from PR #31 test plan.
+ *
+ * Each sub-test spawns a fresh Node process with isolated env vars so that
+ * module-level singletons (warmPool, POOL_ENABLED, semaphore) initialize
+ * correctly for that test's configuration.
+ *
+ * Usage:
+ *   node scripts/test-pool-manual.mjs
+ */
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(join(__dirname, ".."));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Subprocess runner
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Runs inline ESM code in a fresh Node process with custom env vars.
+ * @returns {{ exitCode: number|null, stdout: string, stderr: string }}
+ */
+function runSubTest(name, code, env, timeoutMs = 90_000) {
+  return new Promise((resolve, reject) => {
+    console.log(`\n${"─".repeat(60)}`);
+    console.log(`[${name}] Starting…`);
+
+    const child = spawn("node", ["--input-type=module"], {
+      env: { ...process.env, ...env },
+      cwd: projectRoot,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => {
+      stdout += d;
+    });
+    child.stderr.on("data", (d) => {
+      stderr += d;
+      // Stream structured log lines to our stderr so they're visible
+      const lines = String(d).split("\n");
+      for (const line of lines) {
+        if (line.trim()) {
+          // Only print structured JSON lines (telemetry) — suppress process noise
+          if (line.startsWith("{")) {
+            process.stderr.write(`  [stderr] ${line}\n`);
+          }
+        }
+      }
+    });
+
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`[${name}] Timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ exitCode: code, stdout, stderr });
+    });
+
+    child.stdin.end(code);
+  });
+}
+
+function parseJsonLines(text) {
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => {
+      try {
+        return JSON.parse(l);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-test A — Item 3: Pool smoke (default config)
+// ─────────────────────────────────────────────────────────────────────────────
+async function subTestA() {
+  const code = `
+import { handleCallTool } from "./dist/dispatcher.js";
+import { warmPool } from "./dist/gemini-runner.js";
+
+// Check that the pool was created (not null)
+const poolEnabled = warmPool !== null;
+process.stdout.write(JSON.stringify({ poolEnabled }) + "\\n");
+
+// Give pool a moment to pre-spawn its processes
+await new Promise(r => setTimeout(r, 500));
+
+const readyCount = warmPool?.readyCount ?? -1;
+process.stdout.write(JSON.stringify({ readyCount }) + "\\n");
+
+const start = Date.now();
+const result = await handleCallTool("ask-gemini", {
+  prompt: "reply with the single word pong",
+  wait: true,
+  waitTimeoutMs: 60_000,
+});
+const durationMs = Date.now() - start;
+
+const content = result.content?.[0]?.text ?? "";
+let parsed = null;
+try { parsed = JSON.parse(content); } catch {}
+
+const ok = !result.isError && parsed?.response !== undefined;
+process.stdout.write(JSON.stringify({ ok, durationMs }) + "\\n");
+if (!ok) {
+  process.stderr.write("result: " + content + "\\n");
+  process.exit(1);
+}
+process.exit(0);
+`;
+
+  const { exitCode, stdout, stderr } = await runSubTest(
+    "Sub-test A (pool smoke, default config)",
+    code,
+    { GEMINI_STRUCTURED_LOGS: "1", GEMINI_SESSION_DB: ":memory:" },
+    120_000
+  );
+
+  const info = parseJsonLines(stdout);
+  const poolInfo = info[0] ?? {};
+  const readyInfo = info[1] ?? {};
+  const resultInfo = info[2] ?? {};
+
+  // Find telemetry line from structured logs
+  const telemetry = parseJsonLines(stderr).find(
+    (l) => l.event === "gemini_request" && l.status === "ok"
+  );
+
+  const pass =
+    exitCode === 0 &&
+    poolInfo.poolEnabled === true &&
+    resultInfo.ok === true;
+
+  console.log(`  poolEnabled = ${poolInfo.poolEnabled}`);
+  console.log(`  readyCount at start = ${readyInfo.readyCount}`);
+  if (telemetry) {
+    console.log(`  telemetry: durationMs=${telemetry.durationMs}, model=${telemetry.model}, status=${telemetry.status}`);
+  }
+  console.log(`  durationMs = ${resultInfo.durationMs}`);
+  console.log(`  exitCode = ${exitCode}`);
+  console.log(`[Sub-test A] ${pass ? "PASS ✓" : "FAIL ✗"}`);
+  return pass;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-test B — Item 4: Pool disabled (GEMINI_POOL_ENABLED=0) fallback
+// ─────────────────────────────────────────────────────────────────────────────
+async function subTestB() {
+  const code = `
+import { handleCallTool } from "./dist/dispatcher.js";
+import { warmPool } from "./dist/gemini-runner.js";
+
+// Pool should be null when POOL_ENABLED=0
+const poolIsNull = warmPool === null;
+process.stdout.write(JSON.stringify({ poolIsNull }) + "\\n");
+
+const start = Date.now();
+const result = await handleCallTool("ask-gemini", {
+  prompt: "reply with the single word pong",
+  wait: true,
+  waitTimeoutMs: 90_000,
+});
+const durationMs = Date.now() - start;
+
+const content = result.content?.[0]?.text ?? "";
+let parsed = null;
+try { parsed = JSON.parse(content); } catch {}
+
+const ok = !result.isError && parsed?.response !== undefined;
+process.stdout.write(JSON.stringify({ ok, durationMs }) + "\\n");
+if (!ok) {
+  process.stderr.write("result: " + content + "\\n");
+  process.exit(1);
+}
+process.exit(0);
+`;
+
+  const { exitCode, stdout, stderr } = await runSubTest(
+    "Sub-test B (GEMINI_POOL_ENABLED=0 fallback)",
+    code,
+    {
+      GEMINI_POOL_ENABLED: "0",
+      GEMINI_STRUCTURED_LOGS: "1",
+      GEMINI_SESSION_DB: ":memory:",
+    },
+    120_000
+  );
+
+  const info = parseJsonLines(stdout);
+  const poolInfo = info[0] ?? {};
+  const resultInfo = info[1] ?? {};
+
+  const telemetry = parseJsonLines(stderr).find(
+    (l) => l.event === "gemini_request" && l.status === "ok"
+  );
+
+  const pass =
+    exitCode === 0 &&
+    poolInfo.poolIsNull === true &&
+    resultInfo.ok === true;
+
+  console.log(`  poolIsNull = ${poolInfo.poolIsNull} (warmPool === null)`);
+  console.log(`  request ok = ${resultInfo.ok}`);
+  if (telemetry) {
+    console.log(`  telemetry: durationMs=${telemetry.durationMs}, model=${telemetry.model}, status=${telemetry.status}`);
+  }
+  console.log(`  durationMs = ${resultInfo.durationMs}`);
+  console.log(`  exitCode = ${exitCode}`);
+  console.log(`[Sub-test B] ${pass ? "PASS ✓" : "FAIL ✗"}`);
+  return pass;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-test C — Item 5: POOL_SIZE=1 with 2 concurrent requests
+// ─────────────────────────────────────────────────────────────────────────────
+async function subTestC() {
+  const code = `
+import { handleCallTool } from "./dist/dispatcher.js";
+
+// Fire two calls simultaneously — the semaphore (MAX_CONCURRENT=1) serializes them.
+// Both should eventually succeed; they're not expected to run in parallel.
+const start = Date.now();
+const [r1, r2] = await Promise.all([
+  handleCallTool("ask-gemini", {
+    prompt: "reply with the single word pong",
+    wait: true,
+    waitTimeoutMs: 180_000,
+  }),
+  handleCallTool("ask-gemini", {
+    prompt: "reply with the single word ping",
+    wait: true,
+    waitTimeoutMs: 180_000,
+  }),
+]);
+const durationMs = Date.now() - start;
+
+const c1 = r1.content?.[0]?.text ?? "";
+const c2 = r2.content?.[0]?.text ?? "";
+let p1 = null, p2 = null;
+try { p1 = JSON.parse(c1); } catch {}
+try { p2 = JSON.parse(c2); } catch {}
+
+const r1ok = !r1.isError && p1?.response !== undefined;
+const r2ok = !r2.isError && p2?.response !== undefined;
+const ok = r1ok && r2ok;
+process.stdout.write(JSON.stringify({ ok, r1ok, r2ok, durationMs }) + "\\n");
+if (!ok) {
+  process.stderr.write("r1: " + c1 + "\\n");
+  process.stderr.write("r2: " + c2 + "\\n");
+  process.exit(1);
+}
+process.exit(0);
+`;
+
+  const { exitCode, stdout } = await runSubTest(
+    "Sub-test C (POOL_SIZE=1, 2 concurrent requests)",
+    code,
+    {
+      GEMINI_POOL_SIZE: "1",
+      GEMINI_MAX_CONCURRENT: "1",
+      GEMINI_STRUCTURED_LOGS: "1",
+      GEMINI_SESSION_DB: ":memory:",
+    },
+    300_000 // 5 min: two serialized cold-ish spawns
+  );
+
+  const info = parseJsonLines(stdout);
+  const result = info[0] ?? {};
+
+  const pass = exitCode === 0 && result.ok === true;
+  console.log(`  r1ok = ${result.r1ok}, r2ok = ${result.r2ok}`);
+  console.log(`  both serialized: ${result.ok} (both completed successfully)`);
+  console.log(`  total durationMs = ${result.durationMs}`);
+  console.log(`  exitCode = ${exitCode}`);
+  console.log(`[Sub-test C] ${pass ? "PASS ✓" : "FAIL ✗"}`);
+  return pass;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-test D — Item 6: Custom model bypasses warm pool
+// ─────────────────────────────────────────────────────────────────────────────
+async function subTestD() {
+  const code = `
+import { handleCallTool } from "./dist/dispatcher.js";
+
+const start = Date.now();
+const result = await handleCallTool("ask-gemini", {
+  prompt: "reply with the single word pong",
+  model: "gemini-2.5-pro",
+  wait: true,
+  waitTimeoutMs: 120_000,
+});
+const durationMs = Date.now() - start;
+
+const content = result.content?.[0]?.text ?? "";
+let parsed = null;
+try { parsed = JSON.parse(content); } catch {}
+
+const ok = !result.isError && parsed?.response !== undefined;
+process.stdout.write(JSON.stringify({ ok, durationMs }) + "\\n");
+if (!ok) {
+  process.stderr.write("result: " + content + "\\n");
+  process.exit(1);
+}
+process.exit(0);
+`;
+
+  const { exitCode, stdout, stderr } = await runSubTest(
+    "Sub-test D (custom model=gemini-2.5-pro, pool bypassed)",
+    code,
+    { GEMINI_STRUCTURED_LOGS: "1", GEMINI_SESSION_DB: ":memory:" },
+    150_000
+  );
+
+  const info = parseJsonLines(stdout);
+  const result = info[0] ?? {};
+
+  // Telemetry: model field will be "gemini-2.5-pro" when custom model is used
+  const telemetry = parseJsonLines(stderr).find(
+    (l) => l.event === "gemini_request" && l.status === "ok"
+  );
+
+  // Pool is bypassed when opts.model is set (usePool requires !opts.model)
+  const modelInLog = telemetry?.model;
+  const poolBypassed = modelInLog === "gemini-2.5-pro"; // model propagated → cold spawn used
+
+  const pass = exitCode === 0 && result.ok === true && poolBypassed;
+  console.log(`  request ok = ${result.ok}`);
+  console.log(`  telemetry model = "${modelInLog}" (expected "gemini-2.5-pro")`);
+  console.log(`  pool bypassed (custom model → cold spawn) = ${poolBypassed}`);
+  console.log(`  durationMs = ${result.durationMs}`);
+  console.log(`  exitCode = ${exitCode}`);
+  console.log(`[Sub-test D] ${pass ? "PASS ✓" : "FAIL ✗"}`);
+  return pass;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Run sub-tests sequentially — concurrent Gemini subprocesses would fight for
+// API quota and confuse telemetry attribution.
+const labels = ["A (pool smoke)", "B (pool disabled)", "C (pool=1, 2 concurrent)", "D (custom model)"];
+const fns = [subTestA, subTestB, subTestC, subTestD];
+const results = [];
+
+for (let i = 0; i < fns.length; i++) {
+  try {
+    results.push(await fns[i]());
+  } catch (err) {
+    console.error(`[${labels[i]}] EXCEPTION: ${err.message}`);
+    results.push(false);
+  }
+}
+
+console.log(`\n${"═".repeat(60)}`);
+console.log(`Summary: ${results.filter(Boolean).length}/${results.length} sub-tests passed`);
+for (let i = 0; i < labels.length; i++) {
+  console.log(`  ${results[i] ? "✓" : "✗"} Sub-test ${labels[i]}`);
+}
+console.log(`${"═".repeat(60)}`);
+
+process.exit(results.every(Boolean) ? 0 : 1);

--- a/scripts/test-sigterm.mjs
+++ b/scripts/test-sigterm.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+/**
+ * SIGTERM-handling tests for PR #31 test plan (items 7 and 8).
+ *
+ * Both sub-tests spawn `node dist/index.js` with piped stdio, perform the
+ * MCP initialize handshake, then send SIGTERM.  We observe that:
+ *   - The server emits the drain message on stderr
+ *   - The server exits cleanly (code 0) within a reasonable timeout
+ *
+ * The MCP stdio transport uses plain newline-delimited JSON (NDJSON).
+ *
+ * Usage:
+ *   node scripts/test-sigterm.mjs
+ */
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(join(__dirname, ".."));
+const serverEntry = join(projectRoot, "dist", "index.js");
+
+const DRAIN_MSG = "[gemini-cli-mcp] received SIGTERM, draining process pool…";
+const STARTED_MSG = "gemini-cli-mcp server started";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MCP message helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function mcpMsg(obj) {
+  return JSON.stringify(obj) + "\n";
+}
+
+const MSG_INITIALIZE = mcpMsg({
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "sigterm-test", version: "1.0" },
+  },
+});
+
+const MSG_INITIALIZED = mcpMsg({
+  jsonrpc: "2.0",
+  method: "notifications/initialized",
+  params: {},
+});
+
+const MSG_ASK_GEMINI = mcpMsg({
+  jsonrpc: "2.0",
+  id: 2,
+  method: "tools/call",
+  params: {
+    name: "ask-gemini",
+    arguments: {
+      prompt: "reply with the single word pong",
+      // No wait:true — we want an async job so the subprocess is in-flight
+      // when SIGTERM arrives
+    },
+  },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Server lifecycle helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function spawnServer(extraEnv = {}) {
+  return spawn("node", [serverEntry], {
+    env: {
+      ...process.env,
+      GEMINI_SESSION_DB: ":memory:",
+      GEMINI_STRUCTURED_LOGS: "1",
+      ...extraEnv,
+    },
+    cwd: projectRoot,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+/**
+ * Wait until a specific substring appears in stderr output.
+ * Resolves with the accumulated stderr string, or rejects on timeout.
+ */
+function waitForStderr(child, substring, timeoutMs = 15_000) {
+  return new Promise((resolve, reject) => {
+    let accumulated = "";
+    const timer = setTimeout(() => {
+      reject(new Error(`Timed out waiting for "${substring}" in stderr after ${timeoutMs}ms.\nAccumulated: ${accumulated}`));
+    }, timeoutMs);
+
+    function onData(chunk) {
+      accumulated += String(chunk);
+      if (accumulated.includes(substring)) {
+        clearTimeout(timer);
+        child.stderr.off("data", onData);
+        resolve(accumulated);
+      }
+    }
+    child.stderr.on("data", onData);
+  });
+}
+
+/**
+ * Wait for the process to exit.
+ * Resolves with { code, signal, stderr } or rejects on timeout.
+ */
+function waitForExit(child, timeoutMs = 10_000, currentStderr = "") {
+  return new Promise((resolve, reject) => {
+    let stderrAcc = currentStderr;
+    child.stderr.on("data", (d) => { stderrAcc += String(d); });
+
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`Process did not exit within ${timeoutMs}ms after SIGTERM. stderr:\n${stderrAcc}`));
+    }, timeoutMs);
+
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal, stderr: stderrAcc });
+    });
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-test E — Item 7: SIGTERM during idle (pool warmed, no active request)
+// ─────────────────────────────────────────────────────────────────────────────
+async function subTestE() {
+  console.log(`\n${"─".repeat(60)}`);
+  console.log("[Sub-test E] SIGTERM during idle server");
+
+  const server = spawnServer();
+  let stderrAcc = "";
+  server.stderr.on("data", (d) => { stderrAcc += String(d); });
+  // Discard stdout (MCP responses go here)
+  server.stdout.resume();
+
+  try {
+    // Wait for server to start
+    await waitForStderr(server, STARTED_MSG, 15_000);
+    console.log("  Server started ✓");
+
+    // Perform MCP handshake so the server is fully initialized
+    server.stdin.write(MSG_INITIALIZE);
+    server.stdin.write(MSG_INITIALIZED);
+
+    // Wait for pool warmup — give pre-spawned processes time to start
+    await new Promise((r) => setTimeout(r, 3_000));
+    console.log("  Pool warmup window elapsed ✓");
+
+    // Send SIGTERM
+    const sigtermAt = Date.now();
+    server.kill("SIGTERM");
+    console.log("  SIGTERM sent ✓");
+
+    // Wait for clean exit
+    const { code, stderr } = await waitForExit(server, 8_000, stderrAcc);
+    const elapsed = Date.now() - sigtermAt;
+
+    const hasDrainMsg = stderr.includes(DRAIN_MSG);
+    const cleanExit = code === 0;
+
+    console.log(`  drain message present = ${hasDrainMsg}`);
+    console.log(`  exit code = ${code} (expected 0)`);
+    console.log(`  exit elapsed = ${elapsed}ms after SIGTERM`);
+
+    const pass = hasDrainMsg && cleanExit;
+    console.log(`[Sub-test E] ${pass ? "PASS ✓" : "FAIL ✗"}`);
+    return pass;
+  } catch (err) {
+    console.error(`[Sub-test E] EXCEPTION: ${err.message}`);
+    server.kill("SIGKILL");
+    return false;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-test F — Item 8: SIGTERM during active (in-flight) request
+// ─────────────────────────────────────────────────────────────────────────────
+async function subTestF() {
+  console.log(`\n${"─".repeat(60)}`);
+  console.log("[Sub-test F] SIGTERM during active (in-flight) request");
+
+  const server = spawnServer();
+  let stderrAcc = "";
+  server.stderr.on("data", (d) => { stderrAcc += String(d); });
+  server.stdout.resume();
+
+  try {
+    // Wait for server to start
+    await waitForStderr(server, STARTED_MSG, 15_000);
+    console.log("  Server started ✓");
+
+    // Full MCP handshake
+    server.stdin.write(MSG_INITIALIZE);
+    server.stdin.write(MSG_INITIALIZED);
+
+    // Give pool a moment to spawn warm processes
+    await new Promise((r) => setTimeout(r, 2_000));
+
+    // Fire an async ask-gemini (no wait:true) — Gemini subprocess starts running
+    server.stdin.write(MSG_ASK_GEMINI);
+    console.log("  ask-gemini sent (async, Gemini subprocess now in-flight) ✓");
+
+    // Brief pause to let the job kick off, then immediately SIGTERM
+    await new Promise((r) => setTimeout(r, 500));
+    const sigtermAt = Date.now();
+    server.kill("SIGTERM");
+    console.log("  SIGTERM sent ✓");
+
+    // Server should exit promptly — drain() only kills idle pool processes.
+    // The in-flight Gemini subprocess is not tracked by the pool, so drain()
+    // resolves immediately and process.exit(0) is called right away.
+    const { code, stderr } = await waitForExit(server, 8_000, stderrAcc);
+    const elapsed = Date.now() - sigtermAt;
+
+    const hasDrainMsg = stderr.includes(DRAIN_MSG);
+    const cleanExit = code === 0;
+    const promptExit = elapsed < 7_000; // should be well under 7 s
+
+    console.log(`  drain message present = ${hasDrainMsg}`);
+    console.log(`  exit code = ${code} (expected 0)`);
+    console.log(`  exit elapsed = ${elapsed}ms after SIGTERM (expected < 7000ms)`);
+
+    const pass = hasDrainMsg && cleanExit && promptExit;
+    console.log(`[Sub-test F] ${pass ? "PASS ✓" : "FAIL ✗"}`);
+    return pass;
+  } catch (err) {
+    console.error(`[Sub-test F] EXCEPTION: ${err.message}`);
+    server.kill("SIGKILL");
+    return false;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────────────────────────
+
+const labels = ["E (SIGTERM idle)", "F (SIGTERM mid-request)"];
+const fns = [subTestE, subTestF];
+const results = [];
+
+for (let i = 0; i < fns.length; i++) {
+  try {
+    results.push(await fns[i]());
+  } catch (err) {
+    console.error(`[${labels[i]}] EXCEPTION: ${err.message}`);
+    results.push(false);
+  }
+}
+
+console.log(`\n${"═".repeat(60)}`);
+console.log(`Summary: ${results.filter(Boolean).length}/${results.length} sub-tests passed`);
+for (let i = 0; i < labels.length; i++) {
+  console.log(`  ${results[i] ? "✓" : "✗"} Sub-test ${labels[i]}`);
+}
+console.log(`${"═".repeat(60)}`);
+
+process.exit(results.every(Boolean) ? 0 : 1);

--- a/src/gemini-runner.ts
+++ b/src/gemini-runner.ts
@@ -83,10 +83,13 @@ const semaphore = new Semaphore(MAX_CONCURRENT);
 // forward the @file token to the CLI for workspace-aware resolution).
 //
 // Env vars:
-//   GEMINI_POOL_ENABLED  "1" (default) | "0" to disable
-//   GEMINI_POOL_SIZE     default = GEMINI_MAX_CONCURRENT
+//   GEMINI_POOL_ENABLED     "1" (default) | "0" to disable
+//   GEMINI_POOL_SIZE        default = GEMINI_MAX_CONCURRENT
+//   GEMINI_POOL_STARTUP_MS  estimated CLI startup time; prompt writes are delayed until this
+//                           many ms after spawn so the CLI is ready to process input (default 12000)
 const POOL_ENABLED = (process.env.GEMINI_POOL_ENABLED ?? "1") !== "0";
 const POOL_SIZE = parseInt(process.env.GEMINI_POOL_SIZE ?? String(MAX_CONCURRENT), 10);
+const POOL_STARTUP_MS = parseInt(process.env.GEMINI_POOL_STARTUP_MS ?? "12000", 10);
 
 export let warmPool: WarmProcessPool | null = null;
 
@@ -97,7 +100,8 @@ if (POOL_ENABLED) {
     {
       HOME: process.env.HOME ?? "",
       PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
-    }
+    },
+    POOL_STARTUP_MS
   );
 }
 
@@ -281,10 +285,25 @@ export function runWithWarmProcess(
       }
     });
 
-    // Write prompt + EOF to trigger processing. Keepalive newlines may already
-    // be buffered in stdin; they are harmless to response content.
-    cp.stdin?.write(prompt + "\n");
-    cp.stdin?.end();
+    // Write prompt + EOF to trigger processing, delaying until the process is
+    // expected to have fully started.  The delay is max(0, wp.readyAt - now):
+    //   • 0 when the process has already been running for ≥ startupMs (steady state)
+    //   • positive only for the very first requests after server startup, when the
+    //     pool processes are still initializing — writing too early means the prompt
+    //     sits in the OS pipe buffer and the CLI only reads it after startup completes
+    //     anyway, but the explicit wait keeps the timeout clock more accurate.
+    // Keepalive newlines may already be buffered in stdin; they are harmless to
+    // response content (the CLI ignores empty lines).
+    const startupWaitMs = Math.max(0, wp.readyAt - Date.now());
+    const writePrompt = () => {
+      cp.stdin?.write(prompt + "\n");
+      cp.stdin?.end();
+    };
+    if (startupWaitMs > 0) {
+      setTimeout(writePrompt, startupWaitMs);
+    } else {
+      writePrompt();
+    }
   });
 }
 

--- a/src/warm-pool.ts
+++ b/src/warm-pool.ts
@@ -10,6 +10,11 @@
  * all buffered NDJSON to stdout in one shot.  A replacement process is spawned
  * immediately so the pool is replenished for the next request.
  *
+ * Each WarmProcess carries a `readyAt` timestamp (spawnedAt + startupMs).
+ * runWithWarmProcess() delays the prompt write until that timestamp so the CLI
+ * has time to fully initialize before receiving input.  The delay is zero for
+ * processes that have already aged past startupMs (steady-state requests).
+ *
  * Measured latency improvement (vs cold spawn):
  *   cold spawn  → first-byte ~13.6 s, total ~17 s
  *   warm process → first-byte ~0.9 s, total ~4.4 s  (≈ 12 s savings)
@@ -23,6 +28,8 @@ const KEEPALIVE_INTERVAL_MS = 5_000;
 export interface WarmProcess {
   cp: ChildProcess;
   pid: number | undefined;
+  /** Absolute timestamp (Date.now()) after which the CLI is expected to be fully started. */
+  readyAt: number;
 }
 
 type Waiter = {
@@ -45,11 +52,15 @@ export class WarmProcessPool {
    * @param poolSize   Number of processes to keep warm (default: GEMINI_MAX_CONCURRENT).
    * @param baseArgs   Args to pass to every spawned `gemini` process (no --prompt).
    * @param env        Restricted env for the subprocess (HOME + PATH).
+   * @param startupMs  Estimated CLI startup time (ms).  Prompt writes are delayed until
+   *                   this many ms after spawn, so the CLI is ready to process input.
+   *                   Defaults to 0 (no delay) — production code passes the env-configured value.
    */
   constructor(
     private readonly poolSize: number,
     private readonly baseArgs: string[],
-    private readonly env: Record<string, string>
+    private readonly env: Record<string, string>,
+    private readonly startupMs: number = 0
   ) {
     for (let i = 0; i < poolSize; i++) {
       this._spawnAndEnqueue();
@@ -68,7 +79,7 @@ export class WarmProcessPool {
     // Drain stderr so a full pipe buffer never stalls the subprocess.
     cp.stderr?.on("data", () => {});
 
-    const wp: WarmProcess = { cp, pid: cp.pid };
+    const wp: WarmProcess = { cp, pid: cp.pid, readyAt: Date.now() + this.startupMs };
 
     // Keepalive: send a bare newline every KEEPALIVE_INTERVAL_MS so the CLI
     // does not exit with "No input provided via stdin" after ~14 s idle.


### PR DESCRIPTION
## Problem

The Gemini CLI takes ~12 s to fully initialize in `--yolo --output-format stream-json` mode (auth, module loading, cache setup) — much longer than the 4.5 s reported by `--version`. Previously, `WarmProcess` objects were handed to callers as soon as they were spawned, so the prompt was written to stdin immediately. For the first requests after server startup, this meant total latency still included the remaining startup time, negating most of the pool's benefit.

Diagnosed via `bench-pool.mjs` after noticing sample 1 was consistently ~12–20 s even with an 8 s warmup window:

```
Before fix (2 s warmup):  warm = [19565, 4699, 3782] ms
Before fix (8 s warmup):  warm = [11917, 4360, 3954] ms  ← startup cost leaking through
After fix  (2 s warmup):  warm = [ 7661, 3444, 4821] ms  ← sample 1 now ~4 s wait + inference
```

## Fix

Add `readyAt` (absolute timestamp = `spawnedAt + startupMs`) to `WarmProcess`. `runWithWarmProcess()` delays the stdin write by `max(0, readyAt - now)`, giving the CLI time to fully initialize before receiving input. For steady-state pre-warmed processes the delay is 0 (no change to hot path).

`startupMs` is read from `GEMINI_POOL_STARTUP_MS` (default `12000`) and passed into `WarmProcessPool` as a constructor argument — the env-var concern stays in `gemini-runner.ts`. Tests pass `startupMs=0` via the constructor default, so no test changes needed.

## Benchmark (3 samples, cache disabled, 2 s warmup)

| Metric | Cold spawn | Warm pool | Δ |
|--------|-----------|-----------|---|
| min | 16024 ms | 3444 ms | -79% |
| avg | 16630 ms | 5309 ms | -68% |
| p50 | 16506 ms | 4821 ms | -71% |
| max | 17361 ms | 7661 ms | -56% |

Sample 1 slowness is now bounded: startup guard caps it at `POOL_STARTUP_MS - elapsed + inference` rather than the full cold-spawn latency.

## Also

- **docs**: add `GEMINI_CACHE_TTL_MS` (default `300000`), `GEMINI_CACHE_MAX_ENTRIES` (default `50`), and `GEMINI_POOL_STARTUP_MS` (default `12000`) to the CLAUDE.md env-var table — previously undocumented; fix test count 244→263
- **scripts**: commit `bench-pool.mjs`, `test-pool-manual.mjs`, `test-sigterm.mjs` used during PR #31 test-plan execution

## Test plan

- [x] `npm test` — 263/263 passing
- [x] `npm run build` — clean tsc
- [x] `bench-pool.mjs` — warm p50 improved from ~19 s to ~5 s vs cold ~17 s
- [x] `GEMINI_POOL_STARTUP_MS=0` — disables guard, reverts to old immediate-write behavior