### PR TITLE
fix: ship dist/index.js with executable permissions in tarball

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] — 2026-03-09
+
+### Fixed
+
+- Published tarball now ships `dist/index.js` with executable permissions (`755`), matching best practice from `@anthropic-ai/claude-code` and `@modelcontextprotocol/create-server`. Previously `tsc` emitted the file as `644` and relied on npm to fix permissions at install time.
+
+### Added
+
+- Development note in README about `npx` not working from within the repo (npm Arborist CWD quirk).
+
 ## [0.2.2] — 2026-03-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ Smoke test:
 echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | node dist/index.js
 ```
 
+> **Note:** `npx @guibarscevicius/gemini-cli-mcp` will not work from inside this repo. npm's Arborist sees the local `package.json` matches the package name and skips installation. Use `node dist/index.js` directly when developing.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guibarscevicius/gemini-cli-mcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Safe MCP server wrapping the official Gemini CLI — stateful sessions, no shell injection, subscription auth",
   "type": "module",
   "bin": {
@@ -11,7 +11,7 @@
   ],
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && chmod +x dist/index.js",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "lint": "eslint src",


### PR DESCRIPTION
## Summary

- Build script now runs `chmod +x dist/index.js` after `tsc`, so the published tarball ships with `755` permissions (matches `@anthropic-ai/claude-code` and `@modelcontextprotocol/create-server`)
- Added dev note in README about `npx` not working from inside the repo (npm Arborist CWD quirk)
- Bump to `0.2.3`

## Context

`npx @guibarscevicius/gemini-cli-mcp` failed with `sh: 1: gemini-cli-mcp: not found` when run from inside the package's own repo. Root cause: npm's Arborist sees the local `package.json` matches the requested package and skips npx cache installation entirely. This only affects contributors developing the package — consumers are unaffected.