### PR TITLE
ci: chain npm publish into release-please workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,7 @@
-name: Publish to npm
+name: Publish to npm (manual)
 
+# Fallback for manual releases or re-publishing a failed release.
+# Normal flow: release-please.yml handles publish automatically.
 on:
   release:
     types: [published]
@@ -43,5 +45,3 @@ jobs:
       - name: Publish
         run: npm publish --access public
         # No NODE_AUTH_TOKEN needed — uses OIDC trusted publishing.
-        # Configure the trusted publisher at:
-        #   npmjs.com/package/@guibarscevicius/gemini-cli-mcp → Settings → Publishing Access

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,8 +11,54 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  publish:
+    name: Publish to npm
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Required for OIDC trusted publishing
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Verify pack contents
+        run: |
+          npm pack --dry-run 2>&1 | tee /tmp/pack-output.txt
+          # Fail if LICENSE is missing from tarball
+          grep -q "LICENSE" /tmp/pack-output.txt || (echo "ERROR: LICENSE not in tarball" && exit 1)
+          # Fail if any .ts source files leaked into dist
+          grep -E "\.ts\b" /tmp/pack-output.txt | grep -v "\.d\.ts" | grep -v "\.js\.map" \
+            && (echo "ERROR: Raw .ts source files in tarball" && exit 1) || true
+
+      - name: Publish
+        run: npm publish --access public
+        # No NODE_AUTH_TOKEN needed — uses OIDC trusted publishing.
+        # Configure the trusted publisher at:
+        #   npmjs.com/package/@guibarscevicius/gemini-cli-mcp → Settings → Publishing Access


### PR DESCRIPTION
## Summary

Fixes the publish gap: `GITHUB_TOKEN`-created releases don't trigger other workflows, so `publish.yml` never fired after release-please created a release.

- Adds a `publish` job to `release-please.yml`, gated on `release_created == 'true'`
- Keeps `publish.yml` as a manual fallback (triggers on manually-created GitHub Releases)
- Publish steps are identical: build → test → verify pack → npm publish (OIDC)

## Test plan

- [ ] **Scenario: next release-please PR triggers publish**
  **Method:** CI — merge a releasable commit, then merge the release PR
  - [ ] **Expected:** publish job runs in the release-please workflow and publishes to npm