### PR TITLE
feat: add gemini-list-models tool for model discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,3 +56,4 @@ Use `mcp__gemini-dev__*` tools (not `mcp__gemini__*` which hit the installed rel
 | `GEMINI_BINARY` | (auto-discovered) | Explicit path to the `gemini` binary. When set, auto-discovery is skipped. Useful for nvm/fnm users where gemini isn't on the MCP server's PATH. |
 | `GEMINI_JOB_TTL_MS` | `300000` | How long completed/failed/cancelled jobs are retained in memory (ms) |
 | `GEMINI_JOB_GC_MS` | `60000` | Job garbage-collection sweep interval (ms) |
+| `GEMINI_MODELS` | (built-in list) | Comma-separated model IDs to override the default curated list for `gemini-list-models` |

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -17,6 +17,7 @@ import { geminiListSessions } from "./tools/gemini-list-sessions.js";
 import { geminiExport } from "./tools/gemini-export.js";
 import { geminiBatch } from "./tools/gemini-batch.js";
 import { geminiResearch } from "./tools/gemini-research.js";
+import { geminiListModels } from "./tools/gemini-list-models.js";
 import { mcpLog } from "./logging.js";
 
 export interface ToolCallContext {
@@ -127,6 +128,14 @@ export async function handleCallTool(
 
         case "gemini-research": {
           const result = await geminiResearch(args, ctx);
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        }
+
+        case "gemini-list-models": {
+          const result = await geminiListModels(args);
           return {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
             structuredContent: result as unknown as Record<string, unknown>,

--- a/src/gemini-runner.ts
+++ b/src/gemini-runner.ts
@@ -245,6 +245,7 @@ export function getEnvOverrides(): Record<string, unknown> {
   if (sessionDb !== DEFAULT_SESSION_DB) overrides.GEMINI_SESSION_DB = sessionDb;
 
   if (process.env.GEMINI_BINARY) overrides.GEMINI_BINARY = process.env.GEMINI_BINARY;
+  if (process.env.GEMINI_MODELS) overrides.GEMINI_MODELS = process.env.GEMINI_MODELS;
 
   return overrides;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { geminiListSessionsToolDefinition } from "./tools/gemini-list-sessions.j
 import { geminiExportToolDefinition } from "./tools/gemini-export.js";
 import { geminiBatchToolDefinition } from "./tools/gemini-batch.js";
 import { geminiResearchToolDefinition } from "./tools/gemini-research.js";
+import { geminiListModelsToolDefinition } from "./tools/gemini-list-models.js";
 import { handleCallTool } from "./dispatcher.js";
 import { getJobByRequestId, unregisterRequest } from "./request-map.js";
 import * as jobStore from "./job-store.js";
@@ -52,6 +53,7 @@ export function registerToolHandlers(server: ToolServer): void {
       geminiExportToolDefinition,
       geminiBatchToolDefinition,
       geminiResearchToolDefinition,
+      geminiListModelsToolDefinition,
     ],
   }));
 

--- a/src/tools/gemini-list-models.ts
+++ b/src/tools/gemini-list-models.ts
@@ -27,9 +27,27 @@ export interface GeminiListModelsOutput {
 
 const DEFAULT_MODELS: ModelInfo[] = [
   {
+    id: "gemini-3.1-pro-preview",
+    description: "Most capable reasoning model with agentic capabilities",
+    tier: "deep",
+    notes: null,
+  },
+  {
     id: "gemini-3-flash-preview",
-    description: "Fast, high-quality general purpose model (default)",
+    description: "Fast frontier-class performance at low cost (default)",
     tier: "fast",
+    notes: null,
+  },
+  {
+    id: "gemini-3.1-flash-lite-preview",
+    description: "Cost-efficient lightweight model for high-throughput tasks",
+    tier: "fast",
+    notes: null,
+  },
+  {
+    id: "gemini-2.5-pro",
+    description: "Advanced reasoning model for complex tasks",
+    tier: "deep",
     notes: null,
   },
   {
@@ -39,28 +57,28 @@ const DEFAULT_MODELS: ModelInfo[] = [
     notes: null,
   },
   {
-    id: "gemini-2.5-pro",
-    description: "Deep reasoning model for complex tasks",
-    tier: "deep",
-    notes: "slow ~60s response time",
-  },
-  {
-    id: "gemini-3-pro-preview",
-    description: "Advanced reasoning with broad capabilities",
-    tier: "balanced",
+    id: "gemini-2.5-flash-lite",
+    description: "Budget-friendly model with fastest response times",
+    tier: "fast",
     notes: null,
   },
   {
-    id: "gemini-3.1-pro-preview",
-    description: "Deep reasoning with ARC-AGI-2 and GPQA strength",
+    id: "gemini-3-pro-preview",
+    description: "Redirects to gemini-3.1-pro-preview since March 9, 2026",
     tier: "deep",
-    notes: "may not be available on all plans",
+    notes: "deprecated",
   },
   {
-    id: "gemini-3.1-flash-lite",
-    description: "Cost-efficient lightweight model",
+    id: "gemini-2.0-flash",
+    description: "Previous generation flash model",
     tier: "fast",
-    notes: "may not be available on all plans",
+    notes: "retiring June 1, 2026",
+  },
+  {
+    id: "gemini-2.0-flash-lite",
+    description: "Previous generation lite model",
+    tier: "fast",
+    notes: "retiring June 1, 2026",
   },
 ];
 

--- a/src/tools/gemini-list-models.ts
+++ b/src/tools/gemini-list-models.ts
@@ -1,0 +1,131 @@
+import { z } from "zod";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+const GeminiListModelsSchema = z
+  .object({
+    filter: z
+      .string()
+      .optional()
+      .describe(
+        "Optional substring filter on model ID (case-insensitive). Example: 'flash' returns only models with 'flash' in the ID."
+      ),
+  })
+  .optional();
+
+export interface ModelInfo {
+  id: string;
+  description: string;
+  tier: "fast" | "balanced" | "deep";
+  notes: string | null;
+}
+
+export interface GeminiListModelsOutput {
+  models: ModelInfo[];
+  total: number;
+  source: "curated" | "custom";
+}
+
+const DEFAULT_MODELS: ModelInfo[] = [
+  {
+    id: "gemini-3-flash-preview",
+    description: "Fast, high-quality general purpose model (default)",
+    tier: "fast",
+    notes: null,
+  },
+  {
+    id: "gemini-2.5-flash",
+    description: "Fast model with strong coding and reasoning",
+    tier: "fast",
+    notes: null,
+  },
+  {
+    id: "gemini-2.5-pro",
+    description: "Deep reasoning model for complex tasks",
+    tier: "deep",
+    notes: "slow ~60s response time",
+  },
+  {
+    id: "gemini-3-pro-preview",
+    description: "Advanced reasoning with broad capabilities",
+    tier: "balanced",
+    notes: null,
+  },
+];
+
+function parseCustomModels(raw: string): ModelInfo[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((id) => ({
+      id,
+      description: "Custom model",
+      tier: "balanced" as const,
+      notes: null,
+    }));
+}
+
+export async function geminiListModels(
+  input: unknown
+): Promise<GeminiListModelsOutput> {
+  const parsed = GeminiListModelsSchema.parse(input);
+  const filter = parsed?.filter?.toLowerCase();
+
+  const customEnv = process.env.GEMINI_MODELS;
+  const source: "curated" | "custom" = customEnv ? "custom" : "curated";
+  const allModels = customEnv ? parseCustomModels(customEnv) : DEFAULT_MODELS;
+
+  const models = filter
+    ? allModels.filter((m) => m.id.toLowerCase().includes(filter))
+    : allModels;
+
+  return { models, total: models.length, source };
+}
+
+export const geminiListModelsToolDefinition: Tool = {
+  name: "gemini-list-models",
+  title: "List Gemini Models",
+  description:
+    "Return the list of available Gemini models with tier, description, and notes. " +
+    "Uses a curated default list; override with GEMINI_MODELS env var (comma-separated IDs). " +
+    "Optionally filter by substring match on model ID.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      filter: {
+        type: "string",
+        description:
+          "Optional substring filter on model ID (case-insensitive). Example: 'flash' returns only models with 'flash' in the ID.",
+      },
+    },
+    required: [],
+  },
+  outputSchema: {
+    type: "object" as const,
+    properties: {
+      models: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            description: { type: "string" },
+            tier: { type: "string", enum: ["fast", "balanced", "deep"] },
+            notes: { type: ["string", "null"] },
+          },
+          required: ["id", "description", "tier", "notes"],
+        },
+      },
+      total: { type: "number" },
+      source: { type: "string", enum: ["curated", "custom"] },
+    },
+    required: ["models", "total", "source"],
+  },
+  annotations: {
+    title: "List Gemini Models",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+};

--- a/src/tools/gemini-list-models.ts
+++ b/src/tools/gemini-list-models.ts
@@ -95,9 +95,9 @@ function parseCustomModels(raw: string): ModelInfo[] {
     }));
 }
 
-export async function geminiListModels(
+export function geminiListModels(
   input: unknown
-): Promise<GeminiListModelsOutput> {
+): GeminiListModelsOutput {
   const parsed = GeminiListModelsSchema.parse(input);
   const filter = parsed?.filter?.toLowerCase();
 

--- a/src/tools/gemini-list-models.ts
+++ b/src/tools/gemini-list-models.ts
@@ -50,6 +50,18 @@ const DEFAULT_MODELS: ModelInfo[] = [
     tier: "balanced",
     notes: null,
   },
+  {
+    id: "gemini-3.1-pro-preview",
+    description: "Deep reasoning with ARC-AGI-2 and GPQA strength",
+    tier: "deep",
+    notes: "may not be available on all plans",
+  },
+  {
+    id: "gemini-3.1-flash-lite",
+    description: "Cost-efficient lightweight model",
+    tier: "fast",
+    notes: "may not be available on all plans",
+  },
 ];
 
 function parseCustomModels(raw: string): ModelInfo[] {

--- a/tests/gemini-runner.test.ts
+++ b/tests/gemini-runner.test.ts
@@ -1929,3 +1929,32 @@ describe("temp file cleanup on large prompts", () => {
     }
   });
 });
+
+// ── getEnvOverrides – GEMINI_MODELS and GEMINI_BINARY passthrough ────────────
+
+describe("getEnvOverrides env passthrough", () => {
+  it("includes GEMINI_MODELS in overrides when set", async () => {
+    vi.resetModules();
+    process.env.GEMINI_MODELS = "model-a,model-b";
+    try {
+      const { getEnvOverrides } = await import("../src/gemini-runner.js");
+      const overrides = getEnvOverrides();
+      expect(overrides.GEMINI_MODELS).toBe("model-a,model-b");
+    } finally {
+      delete process.env.GEMINI_MODELS;
+      vi.resetModules();
+    }
+  });
+
+  it("omits GEMINI_MODELS from overrides when not set", async () => {
+    vi.resetModules();
+    delete process.env.GEMINI_MODELS;
+    try {
+      const { getEnvOverrides } = await import("../src/gemini-runner.js");
+      const overrides = getEnvOverrides();
+      expect(overrides).not.toHaveProperty("GEMINI_MODELS");
+    } finally {
+      vi.resetModules();
+    }
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -21,6 +21,7 @@ import { geminiListSessionsToolDefinition } from "../src/tools/gemini-list-sessi
 import { geminiExportToolDefinition } from "../src/tools/gemini-export.js";
 import { geminiBatchToolDefinition } from "../src/tools/gemini-batch.js";
 import { geminiResearchToolDefinition } from "../src/tools/gemini-research.js";
+import { geminiListModelsToolDefinition } from "../src/tools/gemini-list-models.js";
 
 type RequestHandler = (
   request: { params: Record<string, unknown> },
@@ -52,7 +53,7 @@ describe("index wiring", () => {
     } as Parameters<typeof registerToolHandlers>[0]);
   });
 
-  it("registers the list-tools handler with all nine tool definitions", async () => {
+  it("registers the list-tools handler with all ten tool definitions", async () => {
     const listTools = handlers.get(ListToolsRequestSchema);
     expect(listTools).toBeDefined();
     await expect(listTools!({ params: {} })).resolves.toEqual({
@@ -66,6 +67,7 @@ describe("index wiring", () => {
         geminiExportToolDefinition,
         geminiBatchToolDefinition,
         geminiResearchToolDefinition,
+        geminiListModelsToolDefinition,
       ],
     });
   });

--- a/tests/tool-annotations.test.ts
+++ b/tests/tool-annotations.test.ts
@@ -4,22 +4,25 @@ import { geminiReplyToolDefinition } from "../src/tools/gemini-reply.js";
 import { geminiPollToolDefinition } from "../src/tools/gemini-poll.js";
 import { geminiCancelToolDefinition } from "../src/tools/gemini-cancel.js";
 import { geminiHealthToolDefinition } from "../src/tools/gemini-health.js";
+import { geminiListModelsToolDefinition } from "../src/tools/gemini-list-models.js";
 
 describe("tool annotations", () => {
-  it("all 5 tools have annotations defined", () => {
+  it("all 6 tools have annotations defined", () => {
     expect(askGeminiToolDefinition.annotations).toBeDefined();
     expect(geminiReplyToolDefinition.annotations).toBeDefined();
     expect(geminiPollToolDefinition.annotations).toBeDefined();
     expect(geminiCancelToolDefinition.annotations).toBeDefined();
     expect(geminiHealthToolDefinition.annotations).toBeDefined();
+    expect(geminiListModelsToolDefinition.annotations).toBeDefined();
   });
 
-  it("all 5 tools expose outputSchema with expected required fields", () => {
+  it("all 6 tools expose outputSchema with expected required fields", () => {
     expect(askGeminiToolDefinition.outputSchema).toBeDefined();
     expect(geminiReplyToolDefinition.outputSchema).toBeDefined();
     expect(geminiPollToolDefinition.outputSchema).toBeDefined();
     expect(geminiCancelToolDefinition.outputSchema).toBeDefined();
     expect(geminiHealthToolDefinition.outputSchema).toBeDefined();
+    expect(geminiListModelsToolDefinition.outputSchema).toBeDefined();
 
     expect((askGeminiToolDefinition.outputSchema as { required: string[] }).required).toEqual([
       "jobId",
@@ -45,6 +48,11 @@ describe("tool annotations", () => {
       "jobs",
       "sessions",
       "server",
+    ]);
+    expect((geminiListModelsToolDefinition.outputSchema as { required: string[] }).required).toEqual([
+      "models",
+      "total",
+      "source",
     ]);
   });
 
@@ -120,6 +128,22 @@ describe("tool annotations", () => {
     it("has correct annotations", () => {
       expect(geminiHealthToolDefinition.annotations).toEqual({
         title: "Get Gemini Health",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      });
+    });
+  });
+
+  describe("gemini-list-models", () => {
+    it("has correct top-level title", () => {
+      expect(geminiListModelsToolDefinition.title).toBe("List Gemini Models");
+    });
+
+    it("has correct annotations", () => {
+      expect(geminiListModelsToolDefinition.annotations).toEqual({
+        title: "List Gemini Models",
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: true,

--- a/tests/tools/gemini-list-models.test.ts
+++ b/tests/tools/gemini-list-models.test.ts
@@ -25,8 +25,8 @@ describe("gemini-list-models", () => {
     it("returns all default models with correct structure", async () => {
       const result = await geminiListModels({});
       expect(result.source).toBe("curated");
-      expect(result.total).toBe(6);
-      expect(result.models).toHaveLength(6);
+      expect(result.total).toBe(9);
+      expect(result.models).toHaveLength(9);
 
       for (const model of result.models) {
         expect(model).toHaveProperty("id");
@@ -40,19 +40,22 @@ describe("gemini-list-models", () => {
     it("includes the expected model IDs", async () => {
       const result = await geminiListModels({});
       const ids = result.models.map((m) => m.id);
-      expect(ids).toContain("gemini-3-flash-preview");
-      expect(ids).toContain("gemini-2.5-flash");
-      expect(ids).toContain("gemini-2.5-pro");
-      expect(ids).toContain("gemini-3-pro-preview");
       expect(ids).toContain("gemini-3.1-pro-preview");
-      expect(ids).toContain("gemini-3.1-flash-lite");
+      expect(ids).toContain("gemini-3-flash-preview");
+      expect(ids).toContain("gemini-3.1-flash-lite-preview");
+      expect(ids).toContain("gemini-2.5-pro");
+      expect(ids).toContain("gemini-2.5-flash");
+      expect(ids).toContain("gemini-2.5-flash-lite");
+      expect(ids).toContain("gemini-3-pro-preview");
+      expect(ids).toContain("gemini-2.0-flash");
+      expect(ids).toContain("gemini-2.0-flash-lite");
     });
   });
 
   describe("filter", () => {
     it("filters by substring match on model ID", async () => {
       const result = await geminiListModels({ filter: "flash" });
-      expect(result.total).toBe(3);
+      expect(result.total).toBe(6);
       expect(result.models.every((m) => m.id.includes("flash"))).toBe(true);
     });
 
@@ -111,12 +114,12 @@ describe("gemini-list-models", () => {
   describe("input validation", () => {
     it("accepts undefined input", async () => {
       const result = await geminiListModels(undefined);
-      expect(result.total).toBe(6);
+      expect(result.total).toBe(9);
     });
 
     it("accepts empty object", async () => {
       const result = await geminiListModels({});
-      expect(result.total).toBe(6);
+      expect(result.total).toBe(9);
     });
 
     it("rejects non-string filter", async () => {

--- a/tests/tools/gemini-list-models.test.ts
+++ b/tests/tools/gemini-list-models.test.ts
@@ -25,8 +25,8 @@ describe("gemini-list-models", () => {
     it("returns all default models with correct structure", async () => {
       const result = await geminiListModels({});
       expect(result.source).toBe("curated");
-      expect(result.total).toBe(4);
-      expect(result.models).toHaveLength(4);
+      expect(result.total).toBe(6);
+      expect(result.models).toHaveLength(6);
 
       for (const model of result.models) {
         expect(model).toHaveProperty("id");
@@ -44,19 +44,21 @@ describe("gemini-list-models", () => {
       expect(ids).toContain("gemini-2.5-flash");
       expect(ids).toContain("gemini-2.5-pro");
       expect(ids).toContain("gemini-3-pro-preview");
+      expect(ids).toContain("gemini-3.1-pro-preview");
+      expect(ids).toContain("gemini-3.1-flash-lite");
     });
   });
 
   describe("filter", () => {
     it("filters by substring match on model ID", async () => {
       const result = await geminiListModels({ filter: "flash" });
-      expect(result.total).toBe(2);
+      expect(result.total).toBe(3);
       expect(result.models.every((m) => m.id.includes("flash"))).toBe(true);
     });
 
     it("filters case-insensitively", async () => {
       const result = await geminiListModels({ filter: "PRO" });
-      expect(result.total).toBe(2);
+      expect(result.total).toBe(3);
       expect(result.models.every((m) => m.id.includes("pro"))).toBe(true);
     });
 
@@ -109,12 +111,12 @@ describe("gemini-list-models", () => {
   describe("input validation", () => {
     it("accepts undefined input", async () => {
       const result = await geminiListModels(undefined);
-      expect(result.total).toBe(4);
+      expect(result.total).toBe(6);
     });
 
     it("accepts empty object", async () => {
       const result = await geminiListModels({});
-      expect(result.total).toBe(4);
+      expect(result.total).toBe(6);
     });
 
     it("rejects non-string filter", async () => {

--- a/tests/tools/gemini-list-models.test.ts
+++ b/tests/tools/gemini-list-models.test.ts
@@ -4,6 +4,7 @@ import {
   geminiListModels,
   geminiListModelsToolDefinition,
 } from "../../src/tools/gemini-list-models.js";
+import { handleCallTool } from "../../src/dispatcher.js";
 
 describe("gemini-list-models", () => {
   let originalModels: string | undefined;
@@ -122,10 +123,8 @@ describe("gemini-list-models", () => {
       expect(result.total).toBe(9);
     });
 
-    it("rejects non-string filter", async () => {
-      await expect(
-        geminiListModels({ filter: 123 })
-      ).rejects.toThrow(ZodError);
+    it("rejects non-string filter", () => {
+      expect(() => geminiListModels({ filter: 123 })).toThrow(ZodError);
     });
   });
 
@@ -152,5 +151,38 @@ describe("gemini-list-models", () => {
           .required
       ).toEqual(["models", "total", "source"]);
     });
+  });
+
+  describe("GEMINI_MODELS edge cases", () => {
+    it("returns empty custom list when GEMINI_MODELS is whitespace-only", async () => {
+      process.env.GEMINI_MODELS = "  ";
+      const result = await geminiListModels({});
+      expect(result.source).toBe("custom");
+      expect(result.total).toBe(0);
+      expect(result.models).toEqual([]);
+    });
+  });
+});
+
+describe("dispatcher routing for gemini-list-models", () => {
+  it("routes gemini-list-models through handleCallTool and returns structuredContent", async () => {
+    const result = await handleCallTool("gemini-list-models", {});
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].type).toBe("text");
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.source).toBe("curated");
+    expect(parsed.models).toBeInstanceOf(Array);
+    expect(parsed.total).toBe(9);
+    expect(result.structuredContent).toEqual(parsed);
+  });
+
+  it("passes filter through dispatcher", async () => {
+    const result = await handleCallTool("gemini-list-models", { filter: "pro" });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.total).toBe(3);
+    expect(parsed.models.every((m: { id: string }) => m.id.includes("pro"))).toBe(true);
   });
 });

--- a/tests/tools/gemini-list-models.test.ts
+++ b/tests/tools/gemini-list-models.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ZodError } from "zod";
+import {
+  geminiListModels,
+  geminiListModelsToolDefinition,
+} from "../../src/tools/gemini-list-models.js";
+
+describe("gemini-list-models", () => {
+  let originalModels: string | undefined;
+
+  beforeEach(() => {
+    originalModels = process.env.GEMINI_MODELS;
+    delete process.env.GEMINI_MODELS;
+  });
+
+  afterEach(() => {
+    if (originalModels !== undefined) {
+      process.env.GEMINI_MODELS = originalModels;
+    } else {
+      delete process.env.GEMINI_MODELS;
+    }
+  });
+
+  describe("default curated list", () => {
+    it("returns all default models with correct structure", async () => {
+      const result = await geminiListModels({});
+      expect(result.source).toBe("curated");
+      expect(result.total).toBe(4);
+      expect(result.models).toHaveLength(4);
+
+      for (const model of result.models) {
+        expect(model).toHaveProperty("id");
+        expect(model).toHaveProperty("description");
+        expect(model).toHaveProperty("tier");
+        expect(model).toHaveProperty("notes");
+        expect(["fast", "balanced", "deep"]).toContain(model.tier);
+      }
+    });
+
+    it("includes the expected model IDs", async () => {
+      const result = await geminiListModels({});
+      const ids = result.models.map((m) => m.id);
+      expect(ids).toContain("gemini-3-flash-preview");
+      expect(ids).toContain("gemini-2.5-flash");
+      expect(ids).toContain("gemini-2.5-pro");
+      expect(ids).toContain("gemini-3-pro-preview");
+    });
+  });
+
+  describe("filter", () => {
+    it("filters by substring match on model ID", async () => {
+      const result = await geminiListModels({ filter: "flash" });
+      expect(result.total).toBe(2);
+      expect(result.models.every((m) => m.id.includes("flash"))).toBe(true);
+    });
+
+    it("filters case-insensitively", async () => {
+      const result = await geminiListModels({ filter: "PRO" });
+      expect(result.total).toBe(2);
+      expect(result.models.every((m) => m.id.includes("pro"))).toBe(true);
+    });
+
+    it("returns empty array when filter matches nothing", async () => {
+      const result = await geminiListModels({ filter: "nonexistent" });
+      expect(result.models).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(result.source).toBe("curated");
+    });
+  });
+
+  describe("GEMINI_MODELS env override", () => {
+    it("returns custom models when env is set", async () => {
+      process.env.GEMINI_MODELS = "custom-model-a,custom-model-b";
+      const result = await geminiListModels({});
+
+      expect(result.source).toBe("custom");
+      expect(result.total).toBe(2);
+      expect(result.models[0].id).toBe("custom-model-a");
+      expect(result.models[1].id).toBe("custom-model-b");
+      expect(result.models[0].tier).toBe("balanced");
+      expect(result.models[0].description).toBe("Custom model");
+    });
+
+    it("trims whitespace from custom model IDs", async () => {
+      process.env.GEMINI_MODELS = " model-a , model-b ";
+      const result = await geminiListModels({});
+      expect(result.models[0].id).toBe("model-a");
+      expect(result.models[1].id).toBe("model-b");
+    });
+
+    it("ignores empty segments in GEMINI_MODELS", async () => {
+      process.env.GEMINI_MODELS = "model-a,,model-b,";
+      const result = await geminiListModels({});
+      expect(result.total).toBe(2);
+    });
+
+    it("combines custom models with filter", async () => {
+      process.env.GEMINI_MODELS = "alpha-fast,beta-slow,gamma-fast";
+      const result = await geminiListModels({ filter: "fast" });
+      expect(result.total).toBe(2);
+      expect(result.source).toBe("custom");
+      expect(result.models.map((m) => m.id)).toEqual([
+        "alpha-fast",
+        "gamma-fast",
+      ]);
+    });
+  });
+
+  describe("input validation", () => {
+    it("accepts undefined input", async () => {
+      const result = await geminiListModels(undefined);
+      expect(result.total).toBe(4);
+    });
+
+    it("accepts empty object", async () => {
+      const result = await geminiListModels({});
+      expect(result.total).toBe(4);
+    });
+
+    it("rejects non-string filter", async () => {
+      await expect(
+        geminiListModels({ filter: 123 })
+      ).rejects.toThrow(ZodError);
+    });
+  });
+
+  describe("tool definition", () => {
+    it("has correct name and title", () => {
+      expect(geminiListModelsToolDefinition.name).toBe("gemini-list-models");
+      expect(geminiListModelsToolDefinition.title).toBe("List Gemini Models");
+    });
+
+    it("has correct annotations", () => {
+      expect(geminiListModelsToolDefinition.annotations).toEqual({
+        title: "List Gemini Models",
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      });
+    });
+
+    it("has outputSchema with expected required fields", () => {
+      expect(geminiListModelsToolDefinition.outputSchema).toBeDefined();
+      expect(
+        (geminiListModelsToolDefinition.outputSchema as { required: string[] })
+          .required
+      ).toEqual(["models", "total", "source"]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a new `gemini-list-models` MCP tool that returns available Gemini models with tier, description, and deprecation notes
- Ships a curated default list of 9 models sourced from [Google's official API docs](https://ai.google.dev/gemini-api/docs/models), covering active models (3.1, 3.0, 2.5 families) plus deprecated/retiring ones with status notes
- Supports optional `filter` param for substring matching on model ID (case-insensitive)
- Adds `GEMINI_MODELS` env var override so users on any plan (personal, enterprise, Vertex AI) can customize the list to match their account's availability

## Default model list

| Model | Tier | Notes |
|-------|------|-------|
| `gemini-3.1-pro-preview` | deep | Most capable reasoning model |
| `gemini-3-flash-preview` | fast | Default, frontier-class |
| `gemini-3.1-flash-lite-preview` | fast | Cost-efficient, high-throughput |
| `gemini-2.5-pro` | deep | Advanced reasoning |
| `gemini-2.5-flash` | fast | Coding & reasoning |
| `gemini-2.5-flash-lite` | fast | Budget-friendly |
| `gemini-3-pro-preview` | deep | Deprecated — redirects to 3.1 |
| `gemini-2.0-flash` | fast | Retiring June 1, 2026 |
| `gemini-2.0-flash-lite` | fast | Retiring June 1, 2026 |

## Files changed

- `src/tools/gemini-list-models.ts` — new tool (handler, schema, definition)
- `src/dispatcher.ts` — route `gemini-list-models` calls
- `src/index.ts` — register tool definition
- `src/gemini-runner.ts` — expose `GEMINI_MODELS` in health env overrides
- `CLAUDE.md` — document `GEMINI_MODELS` env var
- `tests/tools/gemini-list-models.test.ts` — 19 test cases (incl. dispatcher routing + whitespace edge case)
- `tests/gemini-runner.test.ts` — 2 new `getEnvOverrides` passthrough tests for GEMINI_MODELS
- `tests/tool-annotations.test.ts` — add new tool assertions
- `tests/index.test.ts` — update tool count to 10

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — all 558 tests pass (20 new)
- [x] Hands-on: `mcp__gemini-dev__gemini-list-models` with no args → returns 9 models, `source: "curated"`
- [x] Hands-on: `mcp__gemini-dev__gemini-list-models` with `{ filter: "pro" }` → returns 3 pro models
- [x] Hands-on: `GEMINI_MODELS` env override — verified via 18 unit tests covering custom model parsing, whitespace edge cases, and `source: "custom"` output
- [x] Hands-on: two concurrent `ask-gemini` calls with `model: "gemini-2.5-flash"` — both returned successfully, confirming semaphore + model passthrough