### PR TITLE
fix: clean up Gemini processes on shutdown

### DIFF
--- a/src/gemini-runner.ts
+++ b/src/gemini-runner.ts
@@ -878,7 +878,11 @@ export async function runGemini(
   prompt: string,
   opts: GeminiOptions = {},
   executor: GeminiExecutor = defaultExecutor,
-  onChunk?: (text: string) => void
+  onChunk?: (text: string) => void,
+  lifecycle?: {
+    onProcessStart?: (cp: ChildProcess) => void;
+    onProcessEnd?: () => void;
+  }
 ): Promise<string> {
   const homeDir = process.env.HOME;
   if (!homeDir) {
@@ -986,7 +990,12 @@ export async function runGemini(
       try {
         ({ result: response, retryCount } = await withRetry(async () => {
           const wp = await warmPool!.acquire(QUEUE_TIMEOUT_MS);
-          return runWithWarmProcess(wp, expandedPrompt, TIMEOUT_MS, onChunk);
+          lifecycle?.onProcessStart?.(wp.cp);
+          try {
+            return await runWithWarmProcess(wp, expandedPrompt, TIMEOUT_MS, onChunk);
+          } finally {
+            lifecycle?.onProcessEnd?.();
+          }
         }, MAX_RETRIES > 0 ? MAX_RETRIES + 1 : 1));
       } catch (err) {
         const homeDirForTelemetry = process.env.HOME ?? "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,8 +41,15 @@ const { version: pkgVersion } = _require("../package.json") as { version: string
 
 type ToolServer = Pick<Server, "setRequestHandler" | "getClientCapabilities" | "elicitInput">;
 type ShutdownServer = { onclose?: (() => void) | undefined };
-type ShutdownProcess = Pick<NodeJS.Process, "on" | "stdin">;
-type ShutdownStdin = Pick<NodeJS.ReadStream, "on"> & Partial<Pick<NodeJS.ReadStream, "off">>;
+type ShutdownSignal = "SIGTERM" | "SIGINT";
+type ShutdownStdin = {
+  on(event: "end" | "close", listener: () => void): unknown;
+  off?: (event: "end" | "close", listener: () => void) => unknown;
+};
+type ShutdownProcess = {
+  on(event: ShutdownSignal, listener: () => void): unknown;
+  stdin: ShutdownStdin;
+};
 
 const DEFAULT_SHUTDOWN_FORCE_KILL_MS = 2000;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,11 @@ const _require = createRequire(import.meta.url);
 const { version: pkgVersion } = _require("../package.json") as { version: string };
 
 type ToolServer = Pick<Server, "setRequestHandler" | "getClientCapabilities" | "elicitInput">;
+type ShutdownServer = { onclose?: (() => void) | undefined };
+type ShutdownProcess = Pick<NodeJS.Process, "on" | "stdin">;
+type ShutdownStdin = Pick<NodeJS.ReadStream, "on"> & Partial<Pick<NodeJS.ReadStream, "off">>;
+
+const DEFAULT_SHUTDOWN_FORCE_KILL_MS = 2000;
 
 export function registerToolHandlers(server: ToolServer): void {
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
@@ -158,12 +163,45 @@ export function createServer(): Server {
 
 const server = createServer();
 
-async function shutdown(signal: string): Promise<void> {
-  process.stderr.write(`[gemini-cli-mcp] received ${signal}, draining process pool…\n`);
-  if (warmPool !== null) {
-    await warmPool.drain();
-  }
-  process.exit(0);
+export function registerShutdownHandlers({
+  process: processRef = process,
+  server: serverRef,
+  shutdown,
+}: {
+  process?: ShutdownProcess;
+  server: ShutdownServer;
+  shutdown: (reason: string) => void;
+}): () => void {
+  let triggered = false;
+  const stdin = processRef.stdin as ShutdownStdin;
+
+  const runShutdown = (reason: string) => {
+    if (triggered) return;
+    triggered = true;
+    shutdown(reason);
+  };
+
+  const onSigterm = () => runShutdown("SIGTERM");
+  const onSigint = () => runShutdown("SIGINT");
+  const onStdinEnd = () => runShutdown("stdin end");
+  const onStdinClose = () => runShutdown("stdin close");
+
+  processRef.on("SIGTERM", onSigterm);
+  processRef.on("SIGINT", onSigint);
+  stdin.on("end", onStdinEnd);
+  stdin.on("close", onStdinClose);
+
+  const previousOnClose = serverRef.onclose;
+  serverRef.onclose = () => {
+    previousOnClose?.();
+    runShutdown("server close");
+  };
+
+  return () => {
+    stdin.off?.("end", onStdinEnd);
+    stdin.off?.("close", onStdinClose);
+    serverRef.onclose = previousOnClose;
+  };
 }
 
 async function main() {
@@ -172,17 +210,32 @@ async function main() {
   // stderr is safe to use — MCP protocol uses stdout/stdin only
   process.stderr.write("gemini-cli-mcp server started\n");
 
-  process.on("SIGTERM", () => {
-    shutdown("SIGTERM").catch((err) => {
-      process.stderr.write(`[gemini-cli-mcp] shutdown error: ${err instanceof Error ? err.message : String(err)}\n`);
-      process.exit(1);
-    });
-  });
-  process.on("SIGINT", () => {
-    shutdown("SIGINT").catch((err) => {
-      process.stderr.write(`[gemini-cli-mcp] shutdown error: ${err instanceof Error ? err.message : String(err)}\n`);
-      process.exit(1);
-    });
+  let shutdownPromise: Promise<void> | undefined;
+  const shutdown = async (reason: string): Promise<void> => {
+    if (shutdownPromise !== undefined) return shutdownPromise;
+
+    shutdownPromise = (async () => {
+      process.stderr.write(`[gemini-cli-mcp] received ${reason}, shutting down Gemini processes…\n`);
+      await jobStore.shutdownPendingJobs("Server shutting down", DEFAULT_SHUTDOWN_FORCE_KILL_MS);
+      if (warmPool !== null) {
+        await warmPool.drain();
+      }
+      await transport.close();
+    })();
+
+    return shutdownPromise;
+  };
+
+  registerShutdownHandlers({
+    server,
+    shutdown: (reason) => {
+      shutdown(reason).then(() => {
+        process.exit(0);
+      }).catch((err) => {
+        process.stderr.write(`[gemini-cli-mcp] shutdown error: ${err instanceof Error ? err.message : String(err)}\n`);
+        process.exit(1);
+      });
+    },
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,14 +42,22 @@ const { version: pkgVersion } = _require("../package.json") as { version: string
 type ToolServer = Pick<Server, "setRequestHandler" | "getClientCapabilities" | "elicitInput">;
 type ShutdownServer = { onclose?: (() => void) | undefined };
 type ShutdownSignal = "SIGTERM" | "SIGINT";
+type ShutdownExit = (code?: number) => never;
 type ShutdownStdin = {
   on(event: "end" | "close", listener: () => void): unknown;
   off?: (event: "end" | "close", listener: () => void) => unknown;
 };
 type ShutdownProcess = {
   on(event: ShutdownSignal, listener: () => void): unknown;
+  exit: ShutdownExit;
+  stderr: { write(chunk: string): boolean };
   stdin: ShutdownStdin;
 };
+type ConnectedServer = ShutdownServer & { connect(transport: StdioServerTransport): Promise<void> };
+type PendingJobShutdown = (
+  reason?: string,
+  forceKillAfterMs?: number
+) => Promise<void>;
 
 const DEFAULT_SHUTDOWN_FORCE_KILL_MS = 2000;
 
@@ -212,20 +220,31 @@ export function registerShutdownHandlers({
 }
 
 async function main() {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  // stderr is safe to use — MCP protocol uses stdout/stdin only
-  process.stderr.write("gemini-cli-mcp server started\n");
+  await startServer();
+}
 
+export async function startServer({
+  server: serverRef = server,
+  transport = new StdioServerTransport(),
+  process: processRef = process,
+  shutdownPendingJobs = jobStore.shutdownPendingJobs,
+  warmPool: warmPoolRef = warmPool,
+}: {
+  server?: ConnectedServer;
+  transport?: StdioServerTransport;
+  process?: ShutdownProcess;
+  shutdownPendingJobs?: PendingJobShutdown;
+  warmPool?: typeof warmPool;
+} = {}): Promise<void> {
   let shutdownPromise: Promise<void> | undefined;
   const shutdown = async (reason: string): Promise<void> => {
     if (shutdownPromise !== undefined) return shutdownPromise;
 
     shutdownPromise = (async () => {
-      process.stderr.write(`[gemini-cli-mcp] received ${reason}, shutting down Gemini processes…\n`);
-      await jobStore.shutdownPendingJobs("Server shutting down", DEFAULT_SHUTDOWN_FORCE_KILL_MS);
-      if (warmPool !== null) {
-        await warmPool.drain();
+      processRef.stderr.write(`[gemini-cli-mcp] received ${reason}, shutting down Gemini processes…\n`);
+      await shutdownPendingJobs("Server shutting down", DEFAULT_SHUTDOWN_FORCE_KILL_MS);
+      if (warmPoolRef !== null) {
+        await warmPoolRef.drain();
       }
       await transport.close();
     })();
@@ -234,16 +253,21 @@ async function main() {
   };
 
   registerShutdownHandlers({
-    server,
+    process: processRef,
+    server: serverRef,
     shutdown: (reason) => {
       shutdown(reason).then(() => {
-        process.exit(0);
+        processRef.exit(0);
       }).catch((err) => {
-        process.stderr.write(`[gemini-cli-mcp] shutdown error: ${err instanceof Error ? err.message : String(err)}\n`);
-        process.exit(1);
+        processRef.stderr.write(`[gemini-cli-mcp] shutdown error: ${err instanceof Error ? err.message : String(err)}\n`);
+        processRef.exit(1);
       });
     },
   });
+
+  await serverRef.connect(transport);
+  // stderr is safe to use — MCP protocol uses stdout/stdin only
+  processRef.stderr.write("gemini-cli-mcp server started\n");
 }
 
 const isEntrypoint =

--- a/src/job-store.ts
+++ b/src/job-store.ts
@@ -115,13 +115,59 @@ export function failJob(jobId: string, error: string): void {
 }
 
 export function cancelJob(jobId: string): void {
+  cancelJobWithReason(jobId, "Job was cancelled");
+}
+
+export function cancelJobWithReason(jobId: string, reason: string): void {
   const job = jobs.get(jobId);
   if (job && job.status === "pending") {
     job.status = "cancelled";
     job.subprocess = undefined;
-    job._reject(new Error("Job was cancelled"));
+    job._reject(new Error(reason));
     _jobListChangedCb?.();
   }
+}
+
+export async function shutdownPendingJobs(
+  reason: string = "Server shutting down",
+  forceKillAfterMs: number = 2000
+): Promise<void> {
+  const subprocesses: ChildProcess[] = [];
+
+  for (const [jobId, job] of jobs) {
+    if (job.status !== "pending") continue;
+
+    if (job.subprocess !== undefined) {
+      subprocesses.push(job.subprocess);
+      try {
+        job.subprocess.kill("SIGTERM");
+      } catch {
+        // Ignore kill races; the follow-up cancellation still clears job state.
+      }
+    }
+
+    cancelJobWithReason(jobId, reason);
+    unregisterByJobId(jobId);
+  }
+
+  if (subprocesses.length === 0 || forceKillAfterMs <= 0) return;
+
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      for (const subprocess of subprocesses) {
+        if (subprocess.exitCode === null) {
+          try {
+            subprocess.kill("SIGKILL");
+          } catch {
+            // Process already exited between the liveness check and kill attempt.
+          }
+        }
+      }
+      resolve();
+    }, forceKillAfterMs);
+
+    if (timer.unref) timer.unref();
+  });
 }
 
 /** @internal For test isolation only — not part of the public API. */

--- a/src/job-store.ts
+++ b/src/job-store.ts
@@ -153,6 +153,36 @@ export async function shutdownPendingJobs(
   if (subprocesses.length === 0 || forceKillAfterMs <= 0) return;
 
   await new Promise<void>((resolve) => {
+    let settled = false;
+    const exitListeners = new Map<ChildProcess, { exit: () => void; error: () => void }>();
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      for (const [subprocess, listeners] of exitListeners) {
+        subprocess.off?.("exit", listeners.exit);
+        subprocess.off?.("error", listeners.error);
+      }
+      resolve();
+    };
+    const maybeFinish = () => {
+      if (subprocesses.every((subprocess) => subprocess.exitCode !== null)) {
+        finish();
+      }
+    };
+
+    for (const subprocess of subprocesses) {
+      if (subprocess.exitCode !== null) continue;
+
+      const listeners = {
+        exit: () => maybeFinish(),
+        error: () => maybeFinish(),
+      };
+      exitListeners.set(subprocess, listeners);
+      subprocess.once("exit", listeners.exit);
+      subprocess.once("error", listeners.error);
+    }
+
     const timer = setTimeout(() => {
       for (const subprocess of subprocesses) {
         if (subprocess.exitCode === null) {
@@ -163,10 +193,11 @@ export async function shutdownPendingJobs(
           }
         }
       }
-      resolve();
+      finish();
     }, forceKillAfterMs);
 
     if (timer.unref) timer.unref();
+    maybeFinish();
   });
 }
 

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -60,7 +60,17 @@ export async function runGeminiAsync(
     });
 
   try {
-    const response = await runGemini(prompt, opts, executor, onChunk);
+    const response = await runGemini(prompt, opts, executor, onChunk, {
+      onProcessStart: (cp) => {
+        job.subprocess = cp;
+        if (job.status === "cancelled") {
+          cp.kill("SIGTERM");
+        }
+      },
+      onProcessEnd: () => {
+        job.subprocess = undefined;
+      },
+    });
     return response;
   } finally {
     job.subprocess = undefined;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -9,7 +9,7 @@ vi.mock("../src/dispatcher.js", () => ({
 }));
 
 import { handleCallTool } from "../src/dispatcher.js";
-import { createServer, registerToolHandlers, registerShutdownHandlers } from "../src/index.js";
+import { createServer, registerToolHandlers, registerShutdownHandlers, startServer } from "../src/index.js";
 import { _resetMcpLogger } from "../src/logging.js";
 import { STATIC_RESOURCES, RESOURCE_TEMPLATES } from "../src/resources.js";
 import { askGeminiToolDefinition } from "../src/tools/ask-gemini.js";
@@ -240,5 +240,59 @@ describe("registerShutdownHandlers", () => {
     expect(shutdown).toHaveBeenCalledTimes(1);
     expect(shutdown).toHaveBeenCalledWith("stdin end");
     restore();
+  });
+});
+
+describe("startServer", () => {
+  it("registers shutdown handlers before connect resolves", async () => {
+    const signalHandlers = new Map<string, () => void>();
+    const stdinListeners = new Map<string, () => void>();
+    const processLike = {
+      on: vi.fn((event: string, listener: () => void) => {
+        signalHandlers.set(event, listener);
+      }),
+      exit: vi.fn(),
+      stderr: { write: vi.fn(() => true) },
+      stdin: {
+        on: vi.fn((event: string, listener: () => void) => {
+          stdinListeners.set(event, listener);
+        }),
+        off: vi.fn(),
+      },
+    } as any;
+    const transport = { close: vi.fn().mockResolvedValue(undefined) } as any;
+    const connectStarted = Promise.withResolvers<void>();
+    const connectDone = Promise.withResolvers<void>();
+    const server = {
+      connect: vi.fn(async () => {
+        connectStarted.resolve();
+        await connectDone.promise;
+      }),
+    } as any;
+    const shutdownPendingJobs = vi.fn().mockResolvedValue(undefined);
+    const warmPool = null;
+
+    const startPromise = startServer({
+      server,
+      transport,
+      process: processLike,
+      shutdownPendingJobs,
+      warmPool,
+    });
+
+    await connectStarted.promise;
+
+    expect(signalHandlers.has("SIGINT")).toBe(true);
+    expect(signalHandlers.has("SIGTERM")).toBe(true);
+    expect(stdinListeners.has("end")).toBe(true);
+    expect(stdinListeners.has("close")).toBe(true);
+
+    signalHandlers.get("SIGTERM")?.();
+    await Promise.resolve();
+
+    expect(shutdownPendingJobs).toHaveBeenCalledWith("Server shutting down", 2000);
+
+    connectDone.resolve();
+    await startPromise;
   });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -9,7 +9,7 @@ vi.mock("../src/dispatcher.js", () => ({
 }));
 
 import { handleCallTool } from "../src/dispatcher.js";
-import { createServer, registerToolHandlers } from "../src/index.js";
+import { createServer, registerToolHandlers, registerShutdownHandlers } from "../src/index.js";
 import { _resetMcpLogger } from "../src/logging.js";
 import { STATIC_RESOURCES, RESOURCE_TEMPLATES } from "../src/resources.js";
 import { askGeminiToolDefinition } from "../src/tools/ask-gemini.js";
@@ -187,5 +187,58 @@ describe("index wiring", () => {
     const handler = server._requestHandlers.get("resources/templates/list")!;
     const result = await handler({ method: "resources/templates/list", params: {} });
     expect(result).toEqual({ resourceTemplates: RESOURCE_TEMPLATES });
+  });
+});
+
+describe("registerShutdownHandlers", () => {
+  const originalStdin = process.stdin;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("runs shutdown once when stdin ends and server closes", async () => {
+    const shutdown = vi.fn().mockResolvedValue(undefined);
+    const on = vi.fn();
+    const stdin = { on } as unknown as NodeJS.ReadStream;
+    const signalHandlers = new Map<string, () => void>();
+    const processLike = {
+      on: vi.fn((event: string, handler: () => void) => {
+        signalHandlers.set(event, handler);
+        return process;
+      }),
+      stdin,
+    } as unknown as NodeJS.Process;
+    const server = {} as { onclose?: () => void };
+
+    const restore = registerShutdownHandlers({
+      process: processLike,
+      server,
+      shutdown,
+    });
+
+    const endHandler = on.mock.calls.find(([event]) => event === "end")?.[1] as (() => void) | undefined;
+    const closeHandler = on.mock.calls.find(([event]) => event === "close")?.[1] as (() => void) | undefined;
+
+    expect(endHandler).toBeTypeOf("function");
+    expect(closeHandler).toBeTypeOf("function");
+    expect(server.onclose).toBeTypeOf("function");
+    expect(signalHandlers.has("SIGINT")).toBe(true);
+    expect(signalHandlers.has("SIGTERM")).toBe(true);
+
+    endHandler?.();
+    server.onclose?.();
+    closeHandler?.();
+    signalHandlers.get("SIGINT")?.();
+
+    await vi.runAllTimersAsync();
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(shutdown).toHaveBeenCalledWith("stdin end");
+    restore();
   });
 });

--- a/tests/job-store.test.ts
+++ b/tests/job-store.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
 import {
   appendChunk,
   cancelJob,
@@ -154,32 +155,65 @@ describe("cancelJob", () => {
 });
 
 describe("shutdownPendingJobs", () => {
+  it("resolves before the force-kill deadline when subprocesses exit after SIGTERM", async () => {
+    vi.useFakeTimers();
+    createJob("graceful-job");
+
+    const child = new EventEmitter() as EventEmitter & {
+      kill: ReturnType<typeof vi.fn>;
+      exitCode: number | null;
+    };
+    child.exitCode = null;
+    child.kill = vi.fn((signal: string) => {
+      if (signal === "SIGTERM") {
+        child.exitCode = 0;
+        child.emit("exit", 0, null);
+      }
+      return true;
+    });
+    getJob("graceful-job")!.subprocess = child as any;
+
+    const shutdownPromise = shutdownPendingJobs("Server shutting down", 2000);
+    await Promise.resolve();
+
+    await expect(shutdownPromise).resolves.toBeUndefined();
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(child.kill).toHaveBeenCalledTimes(1);
+  });
+
   it("cancels pending jobs, unregisters request ids, and sends SIGTERM then SIGKILL after grace period", async () => {
     vi.useFakeTimers();
     createJob("shutdown-job");
     registerRequest("req-shutdown", "shutdown-job");
 
-    const kill = vi.fn((signal: string) => {
+    const child = new EventEmitter() as EventEmitter & {
+      kill: ReturnType<typeof vi.fn>;
+      exitCode: number | null;
+    };
+    child.exitCode = null;
+    child.kill = vi.fn((signal: string) => {
       if (signal === "SIGKILL") {
-        (child as { exitCode: number | null }).exitCode = 137;
+        child.exitCode = 137;
       }
       return true;
     });
-    const child = { kill, exitCode: null } as any;
-    getJob("shutdown-job")!.subprocess = child;
+    getJob("shutdown-job")!.subprocess = child as any;
 
     const completion = getJob("shutdown-job")!.completion;
     const shutdownPromise = shutdownPendingJobs("Server shutting down", 2000);
 
     await vi.advanceTimersByTimeAsync(1999);
-    expect(kill).toHaveBeenCalledTimes(1);
-    expect(kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(child.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
 
     await vi.advanceTimersByTimeAsync(1);
     await shutdownPromise;
 
-    expect(kill).toHaveBeenCalledTimes(2);
-    expect(kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+    expect(child.kill).toHaveBeenCalledTimes(2);
+    expect(child.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
     expect(getJob("shutdown-job")!.status).toBe("cancelled");
     expect(getJobByRequestId("req-shutdown")).toBeUndefined();
     await expect(completion).rejects.toThrow("Server shutting down");

--- a/tests/job-store.test.ts
+++ b/tests/job-store.test.ts
@@ -8,8 +8,10 @@ import {
   failJob,
   getJob,
   getJobStats,
+  shutdownPendingJobs,
   sweepExpiredJobs,
 } from "../src/job-store.js";
+import { clearMap, getJobByRequestId, registerRequest } from "../src/request-map.js";
 
 beforeEach(() => {
   clearJobs();
@@ -17,6 +19,8 @@ beforeEach(() => {
 
 afterEach(() => {
   clearJobs();
+  clearMap();
+  vi.useRealTimers();
 });
 
 describe("createJob / getJob", () => {
@@ -149,6 +153,51 @@ describe("cancelJob", () => {
   });
 });
 
+describe("shutdownPendingJobs", () => {
+  it("cancels pending jobs, unregisters request ids, and sends SIGTERM then SIGKILL after grace period", async () => {
+    vi.useFakeTimers();
+    createJob("shutdown-job");
+    registerRequest("req-shutdown", "shutdown-job");
+
+    const kill = vi.fn((signal: string) => {
+      if (signal === "SIGKILL") {
+        (child as { exitCode: number | null }).exitCode = 137;
+      }
+      return true;
+    });
+    const child = { kill, exitCode: null } as any;
+    getJob("shutdown-job")!.subprocess = child;
+
+    const completion = getJob("shutdown-job")!.completion;
+    const shutdownPromise = shutdownPendingJobs("Server shutting down", 2000);
+
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(kill).toHaveBeenCalledTimes(1);
+    expect(kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+
+    await vi.advanceTimersByTimeAsync(1);
+    await shutdownPromise;
+
+    expect(kill).toHaveBeenCalledTimes(2);
+    expect(kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+    expect(getJob("shutdown-job")!.status).toBe("cancelled");
+    expect(getJobByRequestId("req-shutdown")).toBeUndefined();
+    await expect(completion).rejects.toThrow("Server shutting down");
+  });
+
+  it("leaves completed and errored jobs untouched", async () => {
+    createJob("done-job");
+    createJob("error-job");
+    completeJob("done-job", "ok");
+    failJob("error-job", "boom");
+
+    await shutdownPendingJobs("Server shutting down", 10);
+
+    expect(getJob("done-job")!.status).toBe("done");
+    expect(getJob("error-job")!.status).toBe("error");
+  });
+});
+
 describe("GC expiry (sweepExpiredJobs)", () => {
   it("deletes completed jobs older than TTL", () => {
     createJob("gc-done");
@@ -189,8 +238,6 @@ describe("GC expiry (sweepExpiredJobs)", () => {
   });
 
   it("GC sweep calls unregisterByJobId for expired jobs", async () => {
-    const { registerRequest, getJobByRequestId, clearMap } = await import("../src/request-map.js");
-    clearMap();
     createJob("gc-unregister");
     registerRequest("req-gc", "gc-unregister");
     getJob("gc-unregister")!.createdAt = 0;
@@ -198,7 +245,6 @@ describe("GC expiry (sweepExpiredJobs)", () => {
     sweepExpiredJobs();
 
     expect(getJobByRequestId("req-gc")).toBeUndefined();
-    clearMap();
   });
 
   it("does NOT delete recent completed jobs within TTL", () => {

--- a/tests/tools/ask-gemini.test.ts
+++ b/tests/tools/ask-gemini.test.ts
@@ -185,7 +185,11 @@ describe("askGemini", () => {
       "What is the weather?",
       expect.objectContaining({ model: undefined, cwd: undefined, tool: "ask-gemini" }),
       expect.any(Function), // custom executor
-      expect.any(Function)  // onChunk
+      expect.any(Function), // onChunk
+      expect.objectContaining({
+        onProcessStart: expect.any(Function),
+        onProcessEnd: expect.any(Function),
+      })
     );
   });
 
@@ -196,7 +200,8 @@ describe("askGemini", () => {
       "hello",
       expect.objectContaining({ model: "gemini-2.5-pro" }),
       expect.any(Function),
-      expect.any(Function)
+      expect.any(Function),
+      expect.any(Object)
     );
   });
 
@@ -207,7 +212,8 @@ describe("askGemini", () => {
       "review @src/auth.ts",
       expect.objectContaining({ cwd: "/my/project" }),
       expect.any(Function),
-      expect.any(Function)
+      expect.any(Function),
+      expect.any(Object)
     );
   });
 
@@ -218,7 +224,8 @@ describe("askGemini", () => {
       "Check @click.prevent in @a.ts",
       expect.objectContaining({ expandRefs: false }),
       expect.any(Function),
-      expect.any(Function)
+      expect.any(Function),
+      expect.any(Object)
     );
   });
 

--- a/tests/tools/gemini-reply.test.ts
+++ b/tests/tools/gemini-reply.test.ts
@@ -237,7 +237,11 @@ describe("geminiReply", () => {
       "new question",
       expect.objectContaining({ tool: "gemini-reply", sessionId: VALID_SESSION_ID }),
       expect.any(Function),
-      expect.any(Function)
+      expect.any(Function),
+      expect.objectContaining({
+        onProcessStart: expect.any(Function),
+        onProcessEnd: expect.any(Function),
+      })
     );
   });
 
@@ -265,7 +269,8 @@ describe("geminiReply", () => {
       expect.any(String),
       expect.objectContaining({ model: "gemini-2.5-flash" }),
       expect.any(Function),
-      expect.any(Function)
+      expect.any(Function),
+      expect.any(Object)
     );
   });
 
@@ -276,7 +281,8 @@ describe("geminiReply", () => {
       expect.any(String),
       expect.objectContaining({ cwd: "/my/project" }),
       expect.any(Function),
-      expect.any(Function)
+      expect.any(Function),
+      expect.any(Object)
     );
   });
 
@@ -287,7 +293,8 @@ describe("geminiReply", () => {
       expect.any(String),
       expect.objectContaining({ expandRefs: false }),
       expect.any(Function),
-      expect.any(Function)
+      expect.any(Function),
+      expect.any(Object)
     );
   });
 


### PR DESCRIPTION
## Summary

Closes #87.

This change makes `gemini-cli-mcp` shut down Gemini child processes when the MCP server disconnects or exits, instead of only draining the warm pool on `SIGINT`/`SIGTERM`.

Key changes:
- add an idempotent shutdown path that runs on `SIGINT`, `SIGTERM`, stdin `end`, stdin `close`, and MCP `server.onclose`
- bulk-cancel pending jobs with a shutdown-specific reason and request-map cleanup
- send `SIGTERM` first, then escalate to `SIGKILL` after a short grace period for stubborn subprocesses
- track warm-pool borrowed processes in the same job subprocess slot used by cold-spawn jobs so shutdown can terminate either path
- close the startup race by registering shutdown handlers before MCP transport connect finishes
- finish shutdown promptly when child processes exit during the SIGTERM grace period instead of always waiting for the full timeout
- add regression coverage for shutdown orchestration, startup-window teardown, and child-process cleanup timing

## Test Plan

### Automated
- [x] `npm test`
- [x] `npm run build`
- [x] `npx vitest run tests/job-store.test.ts tests/index.test.ts`
- [x] Re-run existing `ask-gemini` and `gemini-reply` tests to confirm the new lifecycle hooks do not change prompt, model, cwd, or `expandRefs` call behavior.
- [x] Re-run the full suite to confirm other affected areas still behave correctly:
  - [x] warm pool behavior
  - [x] request mapping and cancellation
  - [x] wait-timeout background continuation semantics
  - [x] health/reporting and index wiring

### Hands-on
- [x] Start one built MCP server with `node dist/index.js`, close stdin, and verify the process exits with code `0` and logs `received stdin end, shutting down Gemini processes…`.
- [x] Start one built MCP server with `node dist/index.js`, send `SIGTERM`, and verify the process exits with code `0` and logs `received SIGTERM, shutting down Gemini processes…`.
- [x] Start shutdown during server startup and verify the process still cleans up correctly if stdin closes or `SIGTERM` arrives before MCP `connect()` finishes.
- [x] Start a pending Gemini job, trigger shutdown, and verify a child that exits on `SIGTERM` does not wait out the full force-kill grace period.
- [x] Start a pending Gemini job, trigger shutdown, and verify a stubborn child gets `SIGKILL` after the grace period.
- [x] Start two built MCP servers at the same time, close stdin for only the first instance, and verify:
  - [x] the first instance exits cleanly
  - [x] the second instance stays alive
  - [x] shutting down one MCP server instance does not kill another running MCP server instance
- [x] Run the regression checks for shutdown-sensitive job lifecycle paths:
  - [x] completed and errored jobs are left untouched by shutdown
  - [x] shutdown callbacks only run once even when stdin close, server close, and signal handlers all fire

