### PR TITLE
fix(warm-pool): kill the entire gemini process group on shutdown

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,8 @@ const nodeGlobals = {
   Buffer: "readonly",
   __dirname: "readonly",
   __filename: "readonly",
+  // Used in type position (e.g. NodeJS.Signals); declared by @types/node.
+  NodeJS: "readonly",
 };
 
 export default [

--- a/src/gemini-runner.ts
+++ b/src/gemini-runner.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { type ChildProcess } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync, readdirSync } from "node:fs";
 import { readFile, realpath, unlink, writeFile } from "node:fs/promises";
@@ -9,6 +9,7 @@ import pLimit from "p-limit";
 import { WarmProcessPool, type WarmProcess } from "./warm-pool.js";
 import { mcpLog } from "./logging.js";
 import { getCapabilities, buildBaseArgs } from "./cli-capabilities.js";
+import { spawnInGroup, killGroup } from "./process-group.js";
 
 export class GeminiOutputError extends Error {
   constructor(message: string, public sanitizedMessage: string) {
@@ -409,7 +410,7 @@ export function runWithWarmProcess(
     };
 
     timeoutHandle = setTimeout(() => {
-      try { cp.kill("SIGTERM"); } catch { /* already dead */ }
+      killGroup(cp, "SIGTERM");
       settle(() => reject(new Error(`Gemini warm process timed out after ${timeoutMs}ms`)));
     }, timeoutMs);
 
@@ -510,7 +511,7 @@ export function spawnGemini(
   onDone: (fullText: string) => void,
   onError: (err: Error) => void
 ): ChildProcess {
-  const cp = spawn(GEMINI_BINARY, args, {
+  const cp = spawnInGroup(GEMINI_BINARY, args, {
     env: spawnOpts.env,
     cwd: spawnOpts.cwd,
     stdio: ["pipe", "pipe", "pipe"],
@@ -532,7 +533,7 @@ export function spawnGemini(
   };
 
   timeoutHandle = setTimeout(() => {
-    cp.kill("SIGTERM");
+    killGroup(cp, "SIGTERM");
     settle(() =>
       onError(new Error(`Gemini subprocess timed out after ${spawnOpts.timeout}ms`))
     );

--- a/src/job-store.ts
+++ b/src/job-store.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess } from "node:child_process";
+import { killGroup } from "./process-group.js";
 import { unregisterByJobId } from "./request-map.js";
 import { mcpLog } from "./logging.js";
 
@@ -139,11 +140,7 @@ export async function shutdownPendingJobs(
 
     if (job.subprocess !== undefined) {
       subprocesses.push(job.subprocess);
-      try {
-        job.subprocess.kill("SIGTERM");
-      } catch {
-        // Ignore kill races; the follow-up cancellation still clears job state.
-      }
+      killGroup(job.subprocess, "SIGTERM");
     }
 
     cancelJobWithReason(jobId, reason);
@@ -186,11 +183,7 @@ export async function shutdownPendingJobs(
     const timer = setTimeout(() => {
       for (const subprocess of subprocesses) {
         if (subprocess.exitCode === null) {
-          try {
-            subprocess.kill("SIGKILL");
-          } catch {
-            // Process already exited between the liveness check and kill attempt.
-          }
+          killGroup(subprocess, "SIGKILL");
         }
       }
       finish();

--- a/src/process-group.ts
+++ b/src/process-group.ts
@@ -1,0 +1,62 @@
+/**
+ * Process-group spawn / signal helpers (issue #96).
+ *
+ * The npm-published `gemini` binary is a Node shim that re-spawns Node with
+ * `--max-old-space-size=15890` to run the real CLI. So each warm-pool slot is
+ * **two** OS processes: shim (immediate child) → real CLI (grandchild).
+ *
+ * `cp.kill(sig)` only signals the immediate child. The grandchild is
+ * reparented to PID 1 and survives, leaking ~poolSize processes per server
+ * lifecycle.
+ *
+ * Fix on POSIX: spawn each child as a process-group leader (`detached: true`)
+ * and signal the entire group via `process.kill(-pid, sig)`. The kernel then
+ * delivers the signal to every member of the group, including grandchildren.
+ *
+ * Windows is intentionally left on single-PID kill behavior:
+ *   • `detached: true` opens a visible console window per child
+ *     (nodejs/node#21825) — `windowsHide` does not work in combination.
+ *   • The PID-1 reparenting that creates the leak is POSIX-specific; Windows
+ *     uses Job Objects with different lifecycle semantics.
+ */
+
+import { spawn, type SpawnOptions, type ChildProcess } from "node:child_process";
+
+const POSIX = process.platform !== "win32";
+
+/**
+ * Spawn a child as a process-group leader on POSIX so that the entire group
+ * (immediate child + grandchildren spawned by an npm shim) can be signaled
+ * together via {@link killGroup}.
+ *
+ * Caller MUST NOT call `cp.unref()` — the parent must continue to track the
+ * child's `exit` and `close` events.
+ */
+export function spawnInGroup(
+  command: string,
+  args: readonly string[],
+  options: SpawnOptions,
+): ChildProcess {
+  return spawn(command, args, { ...options, detached: POSIX });
+}
+
+/**
+ * Send `signal` to the entire process group on POSIX, falling back to a
+ * single-PID kill on Windows.
+ *
+ * Returns `true` if the signal was delivered, `false` if the child has
+ * already exited, has no PID yet, or the signal call threw (e.g. ESRCH when
+ * the group is already gone). Never throws.
+ */
+export function killGroup(cp: ChildProcess, signal: NodeJS.Signals = "SIGTERM"): boolean {
+  if (cp.exitCode !== null) return false;
+  const pid = cp.pid;
+  if (pid === undefined) return false;
+  try {
+    if (POSIX) process.kill(-pid, signal);
+    else cp.kill(signal);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/process-group.ts
+++ b/src/process-group.ts
@@ -24,6 +24,11 @@ import { spawn, type SpawnOptions, type ChildProcess } from "node:child_process"
 
 const POSIX = process.platform !== "win32";
 
+// Derive the signal type from ChildProcess.kill's signature so we don't have
+// to reference the `NodeJS.` global namespace directly (ESLint no-undef would
+// flag it; @types/node exposes NodeJS.Signals only in type-space).
+type Signal = NonNullable<Parameters<ChildProcess["kill"]>[0]>;
+
 /**
  * Spawn a child as a process-group leader on POSIX so that the entire group
  * (immediate child + grandchildren spawned by an npm shim) can be signaled
@@ -48,7 +53,7 @@ export function spawnInGroup(
  * already exited, has no PID yet, or the signal call threw (e.g. ESRCH when
  * the group is already gone). Never throws.
  */
-export function killGroup(cp: ChildProcess, signal: NodeJS.Signals = "SIGTERM"): boolean {
+export function killGroup(cp: ChildProcess, signal: Signal = "SIGTERM"): boolean {
   if (cp.exitCode !== null) return false;
   const pid = cp.pid;
   if (pid === undefined) return false;

--- a/src/process-group.ts
+++ b/src/process-group.ts
@@ -14,8 +14,9 @@
  * delivers the signal to every member of the group, including grandchildren.
  *
  * Windows is intentionally left on single-PID kill behavior:
- *   • `detached: true` opens a visible console window per child
- *     (nodejs/node#21825) — `windowsHide` does not work in combination.
+ *   • `detached: true` opens a visible console window per child on Windows
+ *     because Node's `windowsHide` flag has no effect when `detached` is also
+ *     set (nodejs/node#21825).
  *   • The PID-1 reparenting that creates the leak is POSIX-specific; Windows
  *     uses Job Objects with different lifecycle semantics.
  */
@@ -24,44 +25,56 @@ import { spawn, type SpawnOptions, type ChildProcess } from "node:child_process"
 
 const POSIX = process.platform !== "win32";
 
-// Derive the signal type from ChildProcess.kill's signature so we don't have
-// to reference the `NodeJS.` global namespace directly (ESLint no-undef would
-// flag it; @types/node exposes NodeJS.Signals only in type-space).
-type Signal = NonNullable<Parameters<ChildProcess["kill"]>[0]>;
-
 /**
  * Spawn a child as a process-group leader on POSIX so that the entire group
  * (immediate child + grandchildren spawned by an npm shim) can be signaled
  * together via {@link killGroup}.
  *
- * Caller MUST NOT call `cp.unref()` — the parent must continue to track the
- * child's `exit` and `close` events.
+ * The `detached` option is omitted from the parameter type because this helper
+ * sets it unconditionally — letting a caller pass `detached: false` would
+ * silently undo the entire point of the wrapper.
+ *
+ * Do not call `cp.unref()` on the returned handle: the `exit`/`error`
+ * listeners that pool replenishment relies on would be silently dropped if
+ * the process is unreffed.
  */
 export function spawnInGroup(
   command: string,
   args: readonly string[],
-  options: SpawnOptions,
+  options: Omit<SpawnOptions, "detached">,
 ): ChildProcess {
   return spawn(command, args, { ...options, detached: POSIX });
 }
 
 /**
  * Send `signal` to the entire process group on POSIX, falling back to a
- * single-PID kill on Windows.
+ * single-PID kill on Windows. Never throws.
  *
- * Returns `true` if the signal was delivered, `false` if the child has
- * already exited, has no PID yet, or the signal call threw (e.g. ESRCH when
- * the group is already gone). Never throws.
+ * Returns `true` if the signal was delivered. Returns `false` when:
+ *   • the child has already exited or been signaled (`exitCode`/`signalCode` set),
+ *   • `cp.pid` is undefined (spawn failed before the kernel allocated a PID),
+ *   • `pid` is `0` or `1` — catastrophic-kill guard: `process.kill(-1, sig)`
+ *     would hit every process the user can reach, `-0` would hit this group,
+ *   • the underlying syscall threw. `ESRCH` (group already gone) is silent;
+ *     any other errno (`EPERM`, `EINVAL`, …) is logged to stderr so real
+ *     misconfiguration is not masked as a benign race.
  */
-export function killGroup(cp: ChildProcess, signal: Signal = "SIGTERM"): boolean {
-  if (cp.exitCode !== null) return false;
+export function killGroup(cp: ChildProcess, signal: NodeJS.Signals = "SIGTERM"): boolean {
+  if (cp.exitCode !== null || cp.signalCode !== null) return false;
   const pid = cp.pid;
-  if (pid === undefined) return false;
+  if (pid === undefined || pid <= 1) return false;
   try {
     if (POSIX) process.kill(-pid, signal);
     else cp.kill(signal);
     return true;
-  } catch {
+  } catch (err: unknown) {
+    const code = (err as { code?: string } | null)?.code;
+    if (code !== "ESRCH") {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `[gemini-cli-mcp] killGroup: unexpected ${code ?? "error"} sending ${signal} to ${POSIX ? `group -${pid}` : `pid ${pid}`}: ${msg}\n`,
+      );
+    }
     return false;
   }
 }

--- a/src/tools/gemini-cancel.ts
+++ b/src/tools/gemini-cancel.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { McpError, ErrorCode, type Tool } from "@modelcontextprotocol/sdk/types.js";
 import * as jobStore from "../job-store.js";
+import { killGroup } from "../process-group.js";
 import { unregisterByJobId } from "../request-map.js";
 import { mcpLog } from "../logging.js";
 
@@ -9,11 +10,11 @@ export const GeminiCancelSchema = z.object({
 });
 
 export interface GeminiCancelOutput {
-  cancelled: boolean;   // true if subprocess was killed
+  cancelled: boolean;   // true if the job transitioned from pending to cancelled
   alreadyDone: boolean; // true if job was already done/error/cancelled (idempotent)
 }
 
-/** Cancel an in-flight Gemini job by sending SIGTERM to its subprocess. */
+/** Cancel an in-flight Gemini job by sending SIGTERM to its subprocess group. */
 export async function geminiCancel(input: unknown): Promise<GeminiCancelOutput> {
   const { jobId } = GeminiCancelSchema.parse(input);
   const job = jobStore.getJob(jobId);
@@ -26,7 +27,7 @@ export async function geminiCancel(input: unknown): Promise<GeminiCancelOutput> 
     return { cancelled: false, alreadyDone: true };
   }
 
-  const killed = job.subprocess?.kill("SIGTERM") ?? false;
+  const killed = job.subprocess ? killGroup(job.subprocess, "SIGTERM") : false;
   process.stderr.write(`[gemini-cli-mcp] gemini-cancel: job ${jobId} cancelled (SIGTERM delivered: ${killed})\n`);
   mcpLog("info", "jobs", { event: "job_cancelled", jobId });
   jobStore.cancelJob(jobId);

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -2,6 +2,7 @@ import { countFileRefs, runGemini, spawnGemini, type GeminiExecutor } from "../g
 import * as jobStore from "../job-store.js";
 import type { ToolCallContext } from "../dispatcher.js";
 import { McpError, ErrorCode, type ElicitRequestFormParams } from "@modelcontextprotocol/sdk/types.js";
+import { killGroup } from "../process-group.js";
 import { mcpLog } from "../logging.js";
 
 /**
@@ -53,7 +54,7 @@ export async function runGeminiAsync(
       job.subprocess = cp;
       // Handle the race where cancelJob() ran before the subprocess was spawned.
       if (job.status === "cancelled") {
-        cp.kill("SIGTERM");
+        killGroup(cp, "SIGTERM");
         reject(new Error("Job was cancelled before subprocess started"));
         return;
       }
@@ -64,7 +65,7 @@ export async function runGeminiAsync(
       onProcessStart: (cp) => {
         job.subprocess = cp;
         if (job.status === "cancelled") {
-          cp.kill("SIGTERM");
+          killGroup(cp, "SIGTERM");
         }
       },
       onProcessEnd: () => {

--- a/src/warm-pool.ts
+++ b/src/warm-pool.ts
@@ -20,8 +20,9 @@
  *   warm process → first-byte ~0.9 s, total ~4.4 s  (≈ 12 s savings)
  */
 
-import { spawn, type ChildProcess } from "node:child_process";
+import { type ChildProcess } from "node:child_process";
 import { mcpLog } from "./logging.js";
+import { spawnInGroup, killGroup } from "./process-group.js";
 
 /** Interval between keepalive writes to each idle process (ms). */
 const KEEPALIVE_INTERVAL_MS = 5_000;
@@ -76,7 +77,7 @@ export class WarmProcessPool {
   private _spawnAndEnqueue(): void {
     if (this.draining) return;
 
-    const cp = spawn(this.binary, this.baseArgs, {
+    const cp = spawnInGroup(this.binary, this.baseArgs, {
       env: this.env,
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -223,7 +224,10 @@ export class WarmProcessPool {
       return new Promise<void>((resolve) => {
         wp.cp.on("exit", () => resolve());
         wp.cp.on("error", () => resolve());
-        try { wp.cp.kill("SIGTERM"); } catch { resolve(); }
+        // killGroup never throws: it returns false when the child is already
+        // exited or the group-signal failed (e.g. ESRCH). In either case the
+        // promise must resolve so drain() does not hang.
+        if (!killGroup(wp.cp, "SIGTERM")) resolve();
       });
     });
 

--- a/tests/job-store.test.ts
+++ b/tests/job-store.test.ts
@@ -155,33 +155,56 @@ describe("cancelJob", () => {
 });
 
 describe("shutdownPendingJobs", () => {
+  // Fake child shape required by killGroup: pid > 1, exitCode/signalCode null
+  // until the test emits "exit". Tests spy on process.kill (the POSIX
+  // group-kill path) rather than cp.kill (the Windows fallback). Issue #96.
+  type FakeCp = EventEmitter & {
+    kill: ReturnType<typeof vi.fn>;
+    exitCode: number | null;
+    signalCode: NodeJS.Signals | null;
+    pid: number;
+  };
+
+  function makeCp(pid: number): FakeCp {
+    const cp = new EventEmitter() as FakeCp;
+    cp.exitCode = null;
+    cp.signalCode = null;
+    cp.pid = pid;
+    cp.kill = vi.fn(() => true);
+    return cp;
+  }
+
   it("resolves before the force-kill deadline when subprocesses exit after SIGTERM", async () => {
     vi.useFakeTimers();
     createJob("graceful-job");
 
-    const child = new EventEmitter() as EventEmitter & {
-      kill: ReturnType<typeof vi.fn>;
-      exitCode: number | null;
-    };
-    child.exitCode = null;
-    child.kill = vi.fn((signal: string) => {
-      if (signal === "SIGTERM") {
-        child.exitCode = 0;
-        child.emit("exit", 0, null);
-      }
-      return true;
-    });
+    const child = makeCp(54321);
     getJob("graceful-job")!.subprocess = child as any;
 
-    const shutdownPromise = shutdownPendingJobs("Server shutting down", 2000);
-    await Promise.resolve();
+    // Mock the kernel: SIGTERM to the group → set exitCode + emit "exit".
+    const processKillSpy = vi.spyOn(process, "kill").mockImplementation((pid: number, sig?: string | number) => {
+      if (pid === -54321 && sig === "SIGTERM") {
+        child.exitCode = 0;
+        child.emit("exit", 0, null);
+        return true;
+      }
+      throw new Error(`unexpected process.kill(${pid}, ${String(sig)})`);
+    });
 
-    await expect(shutdownPromise).resolves.toBeUndefined();
-    expect(child.kill).toHaveBeenCalledTimes(1);
-    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    try {
+      const shutdownPromise = shutdownPendingJobs("Server shutting down", 2000);
+      await Promise.resolve();
 
-    await vi.advanceTimersByTimeAsync(2000);
-    expect(child.kill).toHaveBeenCalledTimes(1);
+      await expect(shutdownPromise).resolves.toBeUndefined();
+      expect(processKillSpy).toHaveBeenCalledWith(-54321, "SIGTERM");
+      expect(child.kill).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(2000);
+      // No SIGKILL escalation when SIGTERM already settled the child.
+      expect(processKillSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      processKillSpy.mockRestore();
+    }
   });
 
   it("cancels pending jobs, unregisters request ids, and sends SIGTERM then SIGKILL after grace period", async () => {
@@ -189,34 +212,38 @@ describe("shutdownPendingJobs", () => {
     createJob("shutdown-job");
     registerRequest("req-shutdown", "shutdown-job");
 
-    const child = new EventEmitter() as EventEmitter & {
-      kill: ReturnType<typeof vi.fn>;
-      exitCode: number | null;
-    };
-    child.exitCode = null;
-    child.kill = vi.fn((signal: string) => {
-      if (signal === "SIGKILL") {
+    const child = makeCp(98765);
+    getJob("shutdown-job")!.subprocess = child as any;
+
+    // Kernel mock: SIGTERM is ignored by the (hung) child; SIGKILL settles it.
+    const processKillSpy = vi.spyOn(process, "kill").mockImplementation((pid: number, sig?: string | number) => {
+      if (pid === -98765 && sig === "SIGKILL") {
         child.exitCode = 137;
+        child.emit("exit", null, "SIGKILL");
       }
       return true;
     });
-    getJob("shutdown-job")!.subprocess = child as any;
 
-    const completion = getJob("shutdown-job")!.completion;
-    const shutdownPromise = shutdownPendingJobs("Server shutting down", 2000);
+    try {
+      const completion = getJob("shutdown-job")!.completion;
+      const shutdownPromise = shutdownPendingJobs("Server shutting down", 2000);
 
-    await vi.advanceTimersByTimeAsync(1999);
-    expect(child.kill).toHaveBeenCalledTimes(1);
-    expect(child.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+      await vi.advanceTimersByTimeAsync(1999);
+      expect(processKillSpy).toHaveBeenCalledTimes(1);
+      expect(processKillSpy).toHaveBeenNthCalledWith(1, -98765, "SIGTERM");
 
-    await vi.advanceTimersByTimeAsync(1);
-    await shutdownPromise;
+      await vi.advanceTimersByTimeAsync(1);
+      await shutdownPromise;
 
-    expect(child.kill).toHaveBeenCalledTimes(2);
-    expect(child.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
-    expect(getJob("shutdown-job")!.status).toBe("cancelled");
-    expect(getJobByRequestId("req-shutdown")).toBeUndefined();
-    await expect(completion).rejects.toThrow("Server shutting down");
+      expect(processKillSpy).toHaveBeenCalledTimes(2);
+      expect(processKillSpy).toHaveBeenNthCalledWith(2, -98765, "SIGKILL");
+      expect(child.kill).not.toHaveBeenCalled();
+      expect(getJob("shutdown-job")!.status).toBe("cancelled");
+      expect(getJobByRequestId("req-shutdown")).toBeUndefined();
+      await expect(completion).rejects.toThrow("Server shutting down");
+    } finally {
+      processKillSpy.mockRestore();
+    }
   });
 
   it("leaves completed and errored jobs untouched", async () => {

--- a/tests/process-group.test.ts
+++ b/tests/process-group.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Unit tests for the process-group helpers.
+ *
+ * The helpers branch on `process.platform`, captured at module load. To test
+ * the Windows branch on a Linux CI, the test stubs `process.platform` BEFORE
+ * importing the module via `vi.resetModules()` + dynamic import — the same
+ * pattern documented in CLAUDE.md for module-level singletons.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+
+// ── Mock spawn ───────────────────────────────────────────────────────────────
+
+let lastSpawnArgs: { command: string; args: readonly string[]; options: Record<string, unknown> } | null = null;
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...original,
+    spawn: vi.fn((command: string, args: readonly string[], options: Record<string, unknown>) => {
+      lastSpawnArgs = { command, args, options };
+      return new EventEmitter() as ChildProcess;
+    }),
+  };
+});
+
+beforeEach(() => {
+  lastSpawnArgs = null;
+});
+
+// ── Helper: build a mock ChildProcess with a controllable exitCode ───────────
+
+function makeMockCp(opts: { pid?: number; exitCode?: number | null } = {}): ChildProcess {
+  const cp = new EventEmitter() as ChildProcess;
+  Object.assign(cp, {
+    pid: opts.pid ?? 12345,
+    exitCode: opts.exitCode ?? null,
+    kill: vi.fn(),
+  });
+  return cp;
+}
+
+// ── POSIX branch ─────────────────────────────────────────────────────────────
+
+describe("process-group helpers (POSIX)", () => {
+  // The module's POSIX const is captured at load time; on Linux/macOS CI it
+  // resolves to true without any stubbing.
+
+  it("spawnInGroup passes detached:true on POSIX", async () => {
+    const { spawnInGroup } = await import("../src/process-group.js");
+    spawnInGroup("echo", ["hi"], { stdio: "ignore" });
+    expect(lastSpawnArgs).not.toBeNull();
+    expect(lastSpawnArgs!.options.detached).toBe(true);
+    expect(lastSpawnArgs!.options.stdio).toBe("ignore");
+  });
+
+  it("killGroup signals the negative pid (process group) on POSIX", async () => {
+    const { killGroup } = await import("../src/process-group.js");
+    const cp = makeMockCp({ pid: 7777 });
+    const spy = vi.spyOn(process, "kill").mockReturnValue(true);
+    try {
+      const ok = killGroup(cp, "SIGTERM");
+      expect(ok).toBe(true);
+      expect(spy).toHaveBeenCalledWith(-7777, "SIGTERM");
+      // Falls back to cp.kill should NOT happen on POSIX
+      expect((cp.kill as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("killGroup defaults the signal to SIGTERM", async () => {
+    const { killGroup } = await import("../src/process-group.js");
+    const cp = makeMockCp({ pid: 8888 });
+    const spy = vi.spyOn(process, "kill").mockReturnValue(true);
+    try {
+      killGroup(cp);
+      expect(spy).toHaveBeenCalledWith(-8888, "SIGTERM");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("killGroup returns false (and never throws) when process.kill throws ESRCH", async () => {
+    const { killGroup } = await import("../src/process-group.js");
+    const cp = makeMockCp({ pid: 9999 });
+    const spy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+    });
+    try {
+      expect(() => killGroup(cp, "SIGTERM")).not.toThrow();
+      expect(killGroup(cp, "SIGTERM")).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("killGroup returns false when the child has already exited", async () => {
+    const { killGroup } = await import("../src/process-group.js");
+    const cp = makeMockCp({ pid: 1, exitCode: 0 });
+    const spy = vi.spyOn(process, "kill").mockReturnValue(true);
+    try {
+      expect(killGroup(cp)).toBe(false);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("killGroup returns false when pid is undefined (spawn never produced a PID)", async () => {
+    const { killGroup } = await import("../src/process-group.js");
+    const cp = new EventEmitter() as ChildProcess;
+    Object.assign(cp, { pid: undefined, exitCode: null, kill: vi.fn() });
+    const spy = vi.spyOn(process, "kill").mockReturnValue(true);
+    try {
+      expect(killGroup(cp)).toBe(false);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+// ── Windows branch (simulated) ───────────────────────────────────────────────
+//
+// process.platform is captured at module load, so we stub it BEFORE the
+// dynamic import. resetModules() ensures we get a fresh module evaluation
+// where POSIX = false. After the test, restore platform and reset modules
+// again so other suites see the real platform.
+
+describe("process-group helpers (Windows simulated)", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    vi.resetModules();
+  });
+
+  it("spawnInGroup omits detached on Windows", async () => {
+    const { spawnInGroup } = await import("../src/process-group.js");
+    spawnInGroup("cmd", ["/c", "echo hi"], { stdio: "ignore" });
+    expect(lastSpawnArgs).not.toBeNull();
+    expect(lastSpawnArgs!.options.detached).toBe(false);
+  });
+
+  it("killGroup falls back to cp.kill(signal) on Windows", async () => {
+    const { killGroup } = await import("../src/process-group.js");
+    const cp = makeMockCp({ pid: 4321 });
+    const processKillSpy = vi.spyOn(process, "kill").mockReturnValue(true);
+    try {
+      const ok = killGroup(cp, "SIGTERM");
+      expect(ok).toBe(true);
+      expect((cp.kill as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith("SIGTERM");
+      // process.kill MUST NOT be invoked on Windows — negative-PID groups don't exist.
+      expect(processKillSpy).not.toHaveBeenCalled();
+    } finally {
+      processKillSpy.mockRestore();
+    }
+  });
+
+  it("killGroup returns false when cp.kill throws on Windows", async () => {
+    const { killGroup } = await import("../src/process-group.js");
+    const cp = makeMockCp({ pid: 5555 });
+    (cp.kill as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("kill failed");
+    });
+    expect(() => killGroup(cp, "SIGTERM")).not.toThrow();
+    expect(killGroup(cp, "SIGTERM")).toBe(false);
+  });
+});

--- a/tests/process-group.test.ts
+++ b/tests/process-group.test.ts
@@ -32,11 +32,16 @@ beforeEach(() => {
 
 // ── Helper: build a mock ChildProcess with a controllable exitCode ───────────
 
-function makeMockCp(opts: { pid?: number; exitCode?: number | null } = {}): ChildProcess {
+function makeMockCp(opts: {
+  pid?: number;
+  exitCode?: number | null;
+  signalCode?: NodeJS.Signals | null;
+} = {}): ChildProcess {
   const cp = new EventEmitter() as ChildProcess;
   Object.assign(cp, {
     pid: opts.pid ?? 12345,
     exitCode: opts.exitCode ?? null,
+    signalCode: opts.signalCode ?? null,
     kill: vi.fn(),
   });
   return cp;
@@ -99,13 +104,79 @@ describe("process-group helpers (POSIX)", () => {
 
   it("killGroup returns false when the child has already exited", async () => {
     const { killGroup } = await import("../src/process-group.js");
-    const cp = makeMockCp({ pid: 1, exitCode: 0 });
+    const cp = makeMockCp({ pid: 12345, exitCode: 0 });
     const spy = vi.spyOn(process, "kill").mockReturnValue(true);
     try {
       expect(killGroup(cp)).toBe(false);
       expect(spy).not.toHaveBeenCalled();
     } finally {
       spy.mockRestore();
+    }
+  });
+
+  it("killGroup returns false when the child was already signal-killed (signalCode set)", async () => {
+    // Issue #96 follow-up: when a child is killed by signal, Node leaves
+    // exitCode === null and sets signalCode. Without this guard, killGroup
+    // would re-signal a group whose PID may have been recycled.
+    const { killGroup } = await import("../src/process-group.js");
+    const cp = makeMockCp({ pid: 12345, exitCode: null, signalCode: "SIGTERM" });
+    const spy = vi.spyOn(process, "kill").mockReturnValue(true);
+    try {
+      expect(killGroup(cp)).toBe(false);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("killGroup refuses to signal pid <= 1 (catastrophic-kill guard)", async () => {
+    // process.kill(-1, sig) signals every process the user can reach;
+    // process.kill(-0, sig) signals this process group. Both would be devastating.
+    const { killGroup } = await import("../src/process-group.js");
+    const spy = vi.spyOn(process, "kill").mockReturnValue(true);
+    try {
+      expect(killGroup(makeMockCp({ pid: 0 }))).toBe(false);
+      expect(killGroup(makeMockCp({ pid: 1 }))).toBe(false);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("killGroup logs unexpected (non-ESRCH) errno to stderr", async () => {
+    // Real misconfigurations (EPERM, EINVAL) should never silently masquerade
+    // as "child already exited" — drain would resolve while the group is alive.
+    const { killGroup } = await import("../src/process-group.js");
+    const cp = makeMockCp({ pid: 9999 });
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+    });
+    try {
+      expect(killGroup(cp, "SIGTERM")).toBe(false);
+      const output = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+      expect(output).toContain("EPERM");
+      expect(output).toContain("group -9999");
+    } finally {
+      killSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it("killGroup stays silent on ESRCH (group already gone is the expected race)", async () => {
+    const { killGroup } = await import("../src/process-group.js");
+    const cp = makeMockCp({ pid: 9999 });
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+    });
+    try {
+      expect(killGroup(cp, "SIGTERM")).toBe(false);
+      // ESRCH is the documented benign case; no log should be emitted.
+      expect(stderrSpy).not.toHaveBeenCalled();
+    } finally {
+      killSpy.mockRestore();
+      stderrSpy.mockRestore();
     }
   });
 
@@ -143,7 +214,9 @@ describe("process-group helpers (Windows simulated)", () => {
     vi.resetModules();
   });
 
-  it("spawnInGroup omits detached on Windows", async () => {
+  it("spawnInGroup passes detached:false on Windows", async () => {
+    // Note: the helper always sets `detached`. On POSIX it's true, on Windows
+    // it's false. The test name reflects the assertion, not an "omitted" key.
     const { spawnInGroup } = await import("../src/process-group.js");
     spawnInGroup("cmd", ["/c", "echo hi"], { stdio: "ignore" });
     expect(lastSpawnArgs).not.toBeNull();
@@ -171,7 +244,15 @@ describe("process-group helpers (Windows simulated)", () => {
     (cp.kill as ReturnType<typeof vi.fn>).mockImplementation(() => {
       throw new Error("kill failed");
     });
-    expect(() => killGroup(cp, "SIGTERM")).not.toThrow();
-    expect(killGroup(cp, "SIGTERM")).toBe(false);
+    // Stub stderr so the (expected) unexpected-error log doesn't pollute test output.
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      expect(() => killGroup(cp, "SIGTERM")).not.toThrow();
+      expect(killGroup(cp, "SIGTERM")).toBe(false);
+      // Non-ESRCH errors are logged on Windows just as on POSIX.
+      expect(stderrSpy).toHaveBeenCalled();
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 });

--- a/tests/run-with-warm-process.test.ts
+++ b/tests/run-with-warm-process.test.ts
@@ -30,6 +30,8 @@ function makeWarmProcess(): {
   Object.assign(cp, {
     pid: 42,
     exitCode: null,
+    // killGroup also guards on signalCode (issue #96 follow-up).
+    signalCode: null,
     stdout,
     stdin: { write: stdinWrite, end: stdinEnd },
     stderr: new EventEmitter(),

--- a/tests/run-with-warm-process.test.ts
+++ b/tests/run-with-warm-process.test.ts
@@ -29,6 +29,7 @@ function makeWarmProcess(): {
 
   Object.assign(cp, {
     pid: 42,
+    exitCode: null,
     stdout,
     stdin: { write: stdinWrite, end: stdinEnd },
     stderr: new EventEmitter(),
@@ -248,15 +249,28 @@ describe("runWithWarmProcess", () => {
 
   // ── Timeout ───────────────────────────────────────────────────────────────
 
-  it("rejects on timeout and kills the process", async () => {
+  it("rejects on timeout and kills the entire process group", async () => {
     vi.useFakeTimers();
-    const { wp } = makeWarmProcess();
-    const promise = runWithWarmProcess(wp, "hi", 100, undefined);
+    // Spy on process.kill so the production POSIX group-kill is captured here
+    // instead of escaping to the real kernel.  Issue #96.
+    const killSpy = vi
+      .spyOn(process, "kill")
+      .mockImplementation((pid: number) => {
+        if (pid < 0) return true;
+        throw new Error(`unexpected positive-pid process.kill in test: ${pid}`);
+      });
 
-    const check = expect(promise).rejects.toThrow("timed out after 100ms");
-    await vi.advanceTimersByTimeAsync(110);
-    await check;
+    try {
+      const { wp } = makeWarmProcess();
+      const promise = runWithWarmProcess(wp, "hi", 100, undefined);
 
-    expect((wp.cp.kill as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+      const check = expect(promise).rejects.toThrow("timed out after 100ms");
+      await vi.advanceTimersByTimeAsync(110);
+      await check;
+
+      expect(killSpy).toHaveBeenCalledWith(-wp.pid!, "SIGTERM");
+    } finally {
+      killSpy.mockRestore();
+    }
   });
 });

--- a/tests/tools/gemini-cancel.test.ts
+++ b/tests/tools/gemini-cancel.test.ts
@@ -25,20 +25,34 @@ afterEach(() => {
 const VALID_JOB_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 
 describe("geminiCancel", () => {
-  it("kills subprocess and cancels the job when pending", async () => {
+  it("signals the entire process group and cancels the job when pending (issue #96)", async () => {
     const mockKill = vi.fn().mockReturnValue(true);
     mockGetJob.mockReturnValue({
       status: "pending",
       partialResponse: "",
-      subprocess: { kill: mockKill } as unknown as ChildProcess,
+      subprocess: {
+        kill: mockKill,
+        pid: 4321,
+        exitCode: null,
+        signalCode: null,
+      } as unknown as ChildProcess,
       createdAt: Date.now(),
     });
 
-    const result = await geminiCancel({ jobId: VALID_JOB_ID });
+    // Spy on the POSIX group-kill so the real kernel is never reached.
+    const processKillSpy = vi.spyOn(process, "kill").mockReturnValue(true);
+    try {
+      const result = await geminiCancel({ jobId: VALID_JOB_ID });
 
-    expect(mockKill).toHaveBeenCalledWith("SIGTERM");
-    expect(mockCancelJob).toHaveBeenCalledWith(VALID_JOB_ID);
-    expect(result).toEqual({ cancelled: true, alreadyDone: false });
+      // Issue #96: cancel must signal the *group* (negative pid), not just the
+      // immediate child via cp.kill — the latter leaks the npm-shim grandchild.
+      expect(processKillSpy).toHaveBeenCalledWith(-4321, "SIGTERM");
+      expect(mockKill).not.toHaveBeenCalled();
+      expect(mockCancelJob).toHaveBeenCalledWith(VALID_JOB_ID);
+      expect(result).toEqual({ cancelled: true, alreadyDone: false });
+    } finally {
+      processKillSpy.mockRestore();
+    }
   });
 
   it("works without a subprocess reference (no-op kill)", async () => {

--- a/tests/warm-pool.test.ts
+++ b/tests/warm-pool.test.ts
@@ -18,7 +18,7 @@ type MockStdin = {
   end: ReturnType<typeof vi.fn>;
 };
 
-function makeMockCp(pid = 1): ChildProcess & {
+function makeMockCp(pid = 100): ChildProcess & {
   mockStdin: MockStdin;
   mockExit: (code: number) => void;
 } {
@@ -40,6 +40,9 @@ function makeMockCp(pid = 1): ChildProcess & {
 
   Object.assign(emitter, {
     pid,
+    // killGroup short-circuits when signalCode !== null; mocks must explicitly
+    // mirror the live ChildProcess shape (issue #96 follow-up).
+    signalCode: null,
     stdin,
     stderr: new EventEmitter(),
     kill: vi.fn((signal?: string) => {
@@ -64,8 +67,10 @@ vi.mock("node:child_process", async (importOriginal) => {
   const original = await importOriginal<typeof import("node:child_process")>();
   return {
     ...original,
+    // Start mock PIDs at 100 — real children never get pid <= 1 and the new
+    // catastrophic-kill guard in killGroup refuses pid 0/1.
     spawn: vi.fn(() => {
-      const cp = makeMockCp(spawnCalls.length + 1);
+      const cp = makeMockCp(100 + spawnCalls.length);
       spawnCalls.push(cp);
       return cp;
     }),
@@ -259,6 +264,37 @@ describe("WarmProcessPool", () => {
         [-spawnCalls[1].pid!, "SIGTERM"],
       ]),
     );
+  });
+
+  it("drain() awaits the actual exit event before resolving", async () => {
+    // Hardens the previous test against a refactor that hoists the kill
+    // before the listener attachment. The default beforeEach spy fires
+    // mockExit synchronously inside process.kill, which would mask such a
+    // bug. Here we delay the exit until after drain has had a chance to
+    // resolve, and assert it doesn't.
+    const pool = new WarmProcessPool(1, [], {});
+    const cp = spawnCalls[0];
+
+    // Override: signal is "delivered" but we do NOT trigger mockExit.
+    processKillSpy!.mockImplementation((pid: number) => {
+      if (pid < 0) return true;
+      throw new Error(`unexpected positive-pid process.kill in test: ${pid}`);
+    });
+
+    let resolved = false;
+    const drainPromise = pool.drain().then(() => {
+      resolved = true;
+    });
+
+    // Flush whatever microtasks drain queues — without a real exit, it must wait.
+    await flushMicrotasks();
+    expect(resolved).toBe(false);
+
+    // Now propagate the kill: the kernel would deliver SIGTERM and the cp
+    // would emit "exit". Simulate that and confirm drain settles.
+    cp.mockExit(0);
+    await drainPromise;
+    expect(resolved).toBe(true);
   });
 
   it("drain() rejects pending waiters", async () => {

--- a/tests/warm-pool.test.ts
+++ b/tests/warm-pool.test.ts
@@ -84,12 +84,31 @@ const flushMicrotasks = () => Promise.resolve();
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe("WarmProcessPool", () => {
+  let processKillSpy: ReturnType<typeof vi.spyOn> | undefined;
+
   beforeEach(() => {
     spawnCalls = [];
+    // Production code now signals the entire POSIX process group via
+    // process.kill(-pid, sig). Simulate group-kill propagation by finding the
+    // matching mock cp and triggering its exit (mirrors what the kernel does
+    // for a real child whose group leader is killed). Issue #96.
+    processKillSpy = vi
+      .spyOn(process, "kill")
+      .mockImplementation((pid: number, _sig?: string | number) => {
+        if (pid < 0) {
+          const cp = spawnCalls.find((c) => c.pid === -pid);
+          if (cp && cp.exitCode === null) cp.mockExit(0);
+          return true;
+        }
+        // Should never be called with a positive pid in these tests; throw to
+        // surface accidental real-process signaling instead of silently passing.
+        throw new Error(`unexpected positive-pid process.kill in test: ${pid}`);
+      });
   });
 
   afterEach(async () => {
     vi.useRealTimers();
+    processKillSpy?.mockRestore();
   });
 
   // ── Construction ───────────────────────────────────────────────────────────
@@ -223,21 +242,23 @@ describe("WarmProcessPool", () => {
     await expect(pool.drain()).resolves.toBeUndefined();
   });
 
-  it("drain() kills all ready processes and resolves when they exit", async () => {
+  it("drain() kills the entire process group of every ready process", async () => {
     const pool = new WarmProcessPool(2, [], {});
     expect(pool.readyCount).toBe(2);
 
-    // drain() calls cp.kill("SIGTERM") — mock emits "exit" synchronously
+    // drain() now calls process.kill(-pid, "SIGTERM") to signal the whole
+    // POSIX process group; the spy in beforeEach mirrors that by triggering
+    // mockExit on the matching cp.  Issue #96.
     await pool.drain();
 
     expect(pool.readyCount).toBe(0);
-    // Both processes must have been sent SIGTERM
-    expect((spawnCalls[0].kill as ReturnType<typeof vi.fn>).mock.calls.some(
-      (args: unknown[]) => args[0] === "SIGTERM"
-    )).toBe(true);
-    expect((spawnCalls[1].kill as ReturnType<typeof vi.fn>).mock.calls.some(
-      (args: unknown[]) => args[0] === "SIGTERM"
-    )).toBe(true);
+    const groupKills = processKillSpy!.mock.calls.filter(([pid]) => (pid as number) < 0);
+    expect(groupKills).toEqual(
+      expect.arrayContaining([
+        [-spawnCalls[0].pid!, "SIGTERM"],
+        [-spawnCalls[1].pid!, "SIGTERM"],
+      ]),
+    );
   });
 
   it("drain() rejects pending waiters", async () => {


### PR DESCRIPTION
## Summary

Closes the **primary** signal-propagation gap in #96. The npm-published `gemini` binary is a Node shim that re-spawns Node with `--max-old-space-size=15890` to run the real CLI, so each subprocess is two OS processes. `cp.kill("SIGTERM")` only reaches the shim; the grandchild is reparented to PID 1 and survives — leaking ~50 processes per server lifecycle in the field on v0.7.2.

This PR routes every `cp.kill(sig)` against a `gemini` subprocess through a tiny `killGroup` helper that signals the **entire POSIX process group** via `process.kill(-pid, sig)`. Centralized in `src/process-group.ts` so the platform check and the kill semantics live in exactly one place.

Refs the epic #96 (parent issue tracks three layered improvements as separate sub-issues: #97 PDEATHSIG, #98 eliminate npm shim, #99 startup orphan reaper). This PR ships **the primary fix only**.

### Scope expansion during review

The first iteration migrated only the warm-pool + runner-timeout paths. PR review surfaced **five additional `cp.kill` call sites** still operating on `spawnGemini`-produced (now process-group-leader) children — they would have continued to leak grandchildren. Those have been migrated and the helper hardened in the latest commit.

## Why POSIX-only?

- `detached: true` on Windows opens a visible console window per child ([nodejs/node#21825](https://github.com/nodejs/node/issues/21825)); `windowsHide` does not work in combination.
- `process.kill(-pid, sig)` is undefined on Windows ([nodejs/node#27642](https://github.com/nodejs/node/issues/27642), [nodejs/node#3617](https://github.com/nodejs/node/issues/3617)).
- The PID-1 reparenting that creates the leak is POSIX-specific.

On Windows the helper falls through to `cp.kill(sig)`.

## Changes

| File | Change |
|---|---|
| `src/process-group.ts` (new, ≈40 LOC) | `spawnInGroup()` adds `detached: POSIX`; type now `Omit<SpawnOptions, "detached">` so callers can't silently undo it. `killGroup()` calls `process.kill(-pid, sig)` on POSIX, `cp.kill(sig)` on Windows. Guards: `cp.exitCode !== null \|\| cp.signalCode !== null`, `pid <= 1` (catastrophic-kill protection — `process.kill(-1)` signals everything the user can reach). Non-ESRCH errno is logged to stderr instead of swallowed. Never throws. |
| `src/warm-pool.ts` | `_spawnAndEnqueue` uses `spawnInGroup`; `drain()` uses `killGroup`. |
| `src/gemini-runner.ts` | `spawnGemini` uses `spawnInGroup`; both timeout-kill paths use `killGroup`. |
| `src/tools/gemini-cancel.ts` | `gemini-cancel` MCP tool uses `killGroup`. |
| `src/tools/shared.ts` | Both cancel-during-spawn race handlers use `killGroup`. |
| `src/job-store.ts` | `shutdownPendingJobs` SIGTERM and SIGKILL force-kill use `killGroup`. |
| `eslint.config.js` | `NodeJS` added to `nodeGlobals` so `NodeJS.Signals` (declared by `@types/node` only in type-space) compiles without `no-undef`. |
| `tests/process-group.test.ts` | 14 cases: POSIX vs Windows, signalCode guard, pid<=1 guard, EPERM logging, ESRCH-silent. |
| `tests/warm-pool.test.ts` | drain test asserts `process.kill(-pid, "SIGTERM")` via spy; new drain async-wait test for delayed exit. |
| `tests/run-with-warm-process.test.ts` | timeout test asserts `process.kill(-pid, "SIGTERM")`. |
| `tests/job-store.test.ts` | `shutdownPendingJobs` SIGTERM and SIGKILL tests rewritten to spy on `process.kill(-pid, sig)`. |
| `tests/tools/gemini-cancel.test.ts` | Primary cancel test rewritten to assert group-kill rather than `cp.kill`. |

## Test plan

### Impact coverage audit
- [x] **All files in the diff have been reviewed for points of impact** — Eight `kill`-equivalent call sites identified (3 in warm-pool/runner from initial PR + 5 surfaced by review across `gemini-cancel.ts`, `tools/shared.ts`, `job-store.ts`); all routed through `killGroup`.
- [x] **Every identified impact point has a corresponding test scenario below** — Helper unit tests + per-call-site unit tests with `process.kill` spies + drain regression test against live MCP.
- [x] Uncovered areas (if any): `spawnGemini` timeout path — see "Known coverage gap" below.

### Documentation
- [x] **README / user-facing docs** — _Not affected: README documents the warm-pool feature and env vars; the "MCP cleans up child processes on shutdown" contract was always the documented promise. No user-visible API change._
- [x] **API docs (JSDoc)** — _Updated: `src/process-group.ts` carries JSDoc on both exports referencing #96, the catastrophic-kill guard, and the EPERM-logging behavior. No public MCP tool schema changed._
- [x] **Inline code comments** — _Reviewed and accurate: comments on the helper explain WHY (PID-1 reparenting, Windows console-window regression, errno classification). New tests carry one-line "Issue #96" cross-references._
- [x] **CHANGELOG / migration guide** — _Not affected: release-please owns CHANGELOG generation from the Conventional Commits (`fix:` scope picks up patch bump). No breaking change._
- [x] **LLM / AI docs** (`CLAUDE.md`) — _Not affected: CLAUDE.md key-source-files list still maps 1:1 to source. The new `src/process-group.ts` is small enough that explicit mention isn't required by the existing inventory granularity._
- [x] **Architecture Decision Records** — _Not affected: repo has no `docs/adr/`. The why-POSIX-only rationale lives in this PR description and the helper's JSDoc._
- [x] **Runbooks / ops docs** — _Not affected: no runbooks in repo._
- [x] **Contributing / dev setup** — _Not affected: no CONTRIBUTING.md in repo. CLAUDE.md "Hands-on integration testing (REQUIRED)" gate is satisfied by the scenarios below._
- [x] **Security docs** — _Not affected: no SECURITY.md. The new `pid <= 1` guard is a defensive hardening that strictly REDUCES the risk surface; no new attack surface introduced._
- [x] **Environment / infra docs** — _Not affected: no new env vars; existing pool-related env vars unchanged._
- [x] **Component / design system docs** — _Not affected: CLI/MCP server, no UI surface._
- [x] **Error catalog / troubleshooting** — _Not affected: README "Warm pool not starting" troubleshooting bullet still accurate. New EPERM logging surfaces unexpected kill failures via existing structured-stderr pattern (`[gemini-cli-mcp] killGroup: ...`)._

### Functional scenarios

- [x] **Scenario 1: Basic prompt with `wait: true`**
  **Method:** CLI / MCP tool call
  **Steps:** `mcp__gemini-dev__ask-gemini` with `prompt: "What is 2+2?"`, `wait: true`
  - [x] **Expected:** Response `"4"` returned synchronously through `spawnInGroup`. **Result:** ✅ Returned `"4"`.

- [x] **Scenario 2: Session continuation via `gemini-reply`**
  **Method:** CLI / MCP tool call
  **Steps:** `gemini-reply` with sessionId from scenario 1, prompt `"Now multiply that result by 3"`
  - [x] **Expected:** Response `"12"` (4×3, confirms session round-trip unchanged). **Result:** ✅ Returned `"12"`.

- [x] **Scenario 3: Async lifecycle (no `wait`) + `gemini-poll`**
  **Method:** CLI / MCP tool call
  **Steps:** `ask-gemini` without `wait` → returns `jobId`; `gemini-poll` with that jobId
  - [x] **Expected:** Poll returns `{status: "done", response: ...}`. **Result:** ✅ Confirmed.

- [x] **Scenario 4: Cancel idempotency + group-kill propagation**
  **Method:** CLI / MCP tool call + unit test — _Mid-flight cancel from inside the tool flow is blocked by progressToken streaming (the client blocks ask-gemini until the job settles), so the group-kill assertion is covered by `tests/tools/gemini-cancel.test.ts:28` which asserts `process.kill(-4321, "SIGTERM")` against a spy._
  **Steps:**
  1. Live: cancel a finished jobId via `gemini-cancel`
  2. Unit: `geminiCancel` against a stubbed `subprocess: { pid: 4321, ... }` with `process.kill` spy
  - [x] **Expected (live):** `{cancelled: false, alreadyDone: true}`. **Result:** ✅ Confirmed.
  - [x] **Expected (unit):** `process.kill` called with `(-4321, "SIGTERM")`; the mock `cp.kill` never invoked. **Result:** ✅ Passes in 609/609.

- [x] **Scenario 5: `@file` reference expansion**
  **Method:** CLI / MCP tool call
  **Steps:** `ask-gemini` with prompt `"Look at @src/process-group.ts and tell me what killGroup does on POSIX"`, `cwd` set to repo root
  - [x] **Expected:** Gemini accurately describes the POSIX branch. **Result:** ✅ "On POSIX systems, killGroup sends a signal to the entire process group (including grandchildren) by passing the negative PID to process.kill."

- [x] **Scenario 6: Two concurrent `ask-gemini` calls**
  **Method:** CLI / MCP tool call
  **Steps:** Fire `"Reply with exactly the word: ALPHA"` and `"Reply with exactly the word: BETA"` in parallel
  - [x] **Expected:** Both jobs complete with the requested literals; no semaphore/pool deadlock. **Result:** ✅ Both completed.

### Bug-specific regression check (the actual orphan test for #96)

- [x] **Scenario R: SIGTERM to MCP server triggers `drain()` → entire process group dies**
  **Method:** CLI / process-tree inspection
  **Steps:**
  1. After scenarios 1–6, captured pool: dev MCP `node dist/index.js` (PID 3863793) with children `{ shim 3898705 → grandchild 3898761; shim 3898895 → grandchild 3899134 }`
  2. `kill -TERM 3863793`, sleep 3 s
  3. Probe each PID with `kill -0`
  - [x] **Expected:** All 5 PIDs gone. **Result:** ✅ 5/5 GONE; system-wide `pgrep -af "gemini --yolo"` count 21 → 17, ∆=−4 matching dev-MCP footprint.

- [x] **Scenario R2: Async-job shutdown via SIGTERM + SIGKILL escalation**
  **Method:** Unit test — _Driving live async-job shutdown end-to-end requires a long-running prompt and a hung shim (SIGTERM-ignoring) which can't be reproduced reliably in this MCP harness. Covered by the same `process.kill` spy pattern that proved the #96 regression for the warm-pool path._
  **Steps:** `tests/job-store.test.ts:177-208` and `:210-244` — graceful path (SIGTERM settles) and force-kill path (SIGTERM ignored, SIGKILL after 2 s grace)
  - [x] **Expected:** `process.kill(-54321, "SIGTERM")` and `process.kill(-98765, "SIGKILL")` invoked; mock `cp.kill` never invoked. **Result:** ✅ Passes in 609/609.

### Helper hardening scenarios

- [x] **Scenario H1: Catastrophic-kill guard rejects pid 0 and pid 1**
  **Method:** Unit test — `tests/process-group.test.ts`
  **Steps:** `killGroup(makeMockCp({pid:0}))` and `killGroup(makeMockCp({pid:1}))`
  - [x] **Expected:** Both return `false`; `process.kill` never invoked. **Result:** ✅ Passes.

- [x] **Scenario H2: signalCode guard prevents re-signaling a recycled PID**
  **Method:** Unit test
  **Steps:** `killGroup` against a cp with `exitCode: null, signalCode: "SIGTERM"`
  - [x] **Expected:** Returns `false`; `process.kill` never invoked. **Result:** ✅ Passes.

- [x] **Scenario H3: Non-ESRCH errno is logged to stderr (no silent failure)**
  **Method:** Unit test
  **Steps:** Stub `process.kill` to throw `EPERM`; capture stderr.write
  - [x] **Expected:** stderr output contains `"EPERM"` and `"group -9999"`; killGroup returns `false`. **Result:** ✅ Passes.

- [x] **Scenario H4: ESRCH stays silent (expected race)**
  **Method:** Unit test
  **Steps:** Stub `process.kill` to throw `ESRCH`
  - [x] **Expected:** No stderr output; killGroup returns `false`. **Result:** ✅ Passes.

### Static checks

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] `npm test` — **609 / 609 pass** across 29 files (was 604 → +5 new tests for the new guards)
- [x] `npx eslint src` — clean (`NodeJS.Signals` resolves via the new globals entry)

### Known coverage gap (documented honestly)

> **Note:** `spawnGemini` timeout path lacks a dedicated unit test.** Adding it cleanly requires either real-subprocess scaffolding or a per-test `child_process` mock that would conflict with the existing real-spawn pattern in `tests/gemini-runner.test.ts`. The structurally-identical `runWithWarmProcess` timeout test (`tests/run-with-warm-process.test.ts:252`) plus the helper-level guards (Scenarios H1–H4) cover the same `killGroup` invariant; residual risk is a narrow revert of just `src/gemini-runner.ts:536`. Tracked for future hardening if the ROI justifies the test scaffolding.

## Risk

Low — additive abstraction with a single platform check and strictly-narrowing guards. All Windows behavior preserved exactly. Helper is built to never throw; ESRCH/EPERM/EINVAL handled. Catastrophic-kill (pid≤1) and recycled-PID (signalCode) guards are pure safety additions. Reverting is a 5-line restoration if anything regresses.

Refs #96
