### PR TITLE
refactor: skip gemini-cli self-relaunch via GEMINI_CLI_NO_RELAUNCH (#98)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ scratch/
 
 # Internal development notes (test plans, session logs, personal paths)
 tasks/
+
+# Local autonomous-save / remember tool state (per-machine logs and PID file)
+.remember/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,3 +60,22 @@ Use `mcp__gemini-dev__*` tools (not `mcp__gemini__*` which hit the installed rel
 | `GEMINI_JOB_GC_MS` | `60000` | Job garbage-collection sweep interval (ms) |
 | `GEMINI_SKIP_DETECTION` | `0` | `1` = skip CLI version/flag detection at startup (use hardcoded fallback args) |
 | `GEMINI_MODELS` | (built-in list) | Comma-separated model IDs to override the default curated list for `gemini-list-models` |
+
+## Env vars set on every gemini child (issue #98)
+
+`GEMINI_CHILD_ENV_OVERRIDES` in `src/cli-capabilities.ts` defines env vars
+injected into every spawned `gemini` process. Currently:
+
+- `GEMINI_CLI_NO_RELAUNCH=true` — disables `@google/gemini-cli`'s runtime
+  self-relaunch (`relaunchAppInChildProcess` in `packages/cli/src/utils/relaunch.ts`).
+  Without this, the CLI re-execs itself with `--max-old-space-size=<50% RAM>`,
+  producing two Node processes per warm-pool slot. With it set, we get one
+  process per slot — verifiable via `pgrep -af "gemini --yolo"` (count should
+  equal `GEMINI_POOL_SIZE`, not 2× it). Trade-off: CLI runs at Node's default
+  heap (~4 GB on 64-bit). If a real prompt OOMs we revisit by passing
+  `--max-old-space-size` explicitly.
+
+Contract verified at upstream v0.38.1 (installed) and v0.38.2 (latest). If a
+future release changes the env-var name or removes the gate, the
+`cli-capabilities` and `setup` propagation tests still pass but the integration
+process-tree check fails — that's the canary.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,8 @@ Use `mcp__gemini-dev__*` tools (not `mcp__gemini__*` which hit the installed rel
 injected into every spawned `gemini` process. Currently:
 
 - `GEMINI_CLI_NO_RELAUNCH=true` — disables `@google/gemini-cli`'s runtime
-  self-relaunch (`relaunchAppInChildProcess` in `packages/cli/src/utils/relaunch.ts`).
+  self-relaunch (`relaunchAppInChildProcess`, located at
+  `packages/cli/src/utils/relaunch.ts` in v0.38.x of the upstream repo).
   Without this, the CLI re-execs itself with `--max-old-space-size=<50% RAM>`,
   producing two Node processes per warm-pool slot. With it set, we get one
   process per slot — verifiable via `pgrep -af "gemini --yolo"` (count should
@@ -76,6 +77,8 @@ injected into every spawned `gemini` process. Currently:
   `--max-old-space-size` explicitly.
 
 Contract verified at upstream v0.38.1 (installed) and v0.38.2 (latest). If a
-future release changes the env-var name or removes the gate, the
-`cli-capabilities` and `setup` propagation tests still pass but the integration
-process-tree check fails — that's the canary.
+future release changes the env-var name or removes the gate, the unit
+propagation tests in `cli-capabilities` and `setup` will still pass — they mock
+`spawn`. The only reliable signal is the manual integration step: run
+`pgrep -af "gemini --yolo"` after server startup and verify the count equals
+`GEMINI_POOL_SIZE` (not 2× it).

--- a/src/cli-capabilities.ts
+++ b/src/cli-capabilities.ts
@@ -28,6 +28,25 @@ export const MIN_SUPPORTED_VERSION: CliVersion = {
 
 const DETECTION_TIMEOUT_MS = 5_000;
 
+/**
+ * Env vars injected into every gemini child process.
+ *
+ * `GEMINI_CLI_NO_RELAUNCH=true` short-circuits @google/gemini-cli's runtime
+ * self-relaunch (relaunchAppInChildProcess in packages/cli/src/utils/relaunch.ts),
+ * which would otherwise spawn a second `node --max-old-space-size=<50% RAM>`
+ * to inherit a larger heap. With one Node process per warm-pool slot we get a
+ * flatter process tree, faster pool startup, and no shim-signal-propagation
+ * contract to maintain. Trade-off: CLI runs at Node's default heap (~4 GB on
+ * 64-bit) — sufficient for our concurrency limits.
+ *
+ * Verified contract at @google/gemini-cli v0.38.1 (installed) and v0.38.2
+ * (latest): the env var is checked at the entry of relaunchAppInChildProcess
+ * and used internally by the CLI to prevent relaunch recursion.
+ */
+export const GEMINI_CHILD_ENV_OVERRIDES = {
+  GEMINI_CLI_NO_RELAUNCH: "true",
+} as const;
+
 function parseVersion(output: string): CliVersion | null {
   const match = /(\d+)\.(\d+)\.(\d+)/.exec(output);
   if (!match) return null;
@@ -58,7 +77,11 @@ function runCommand(binary: string, args: string[]): Promise<string> {
     const child = execFile(
       binary,
       args,
-      { timeout: DETECTION_TIMEOUT_MS, encoding: "utf8" },
+      {
+        timeout: DETECTION_TIMEOUT_MS,
+        encoding: "utf8",
+        env: { ...process.env, ...GEMINI_CHILD_ENV_OVERRIDES },
+      },
       (error, stdout, stderr) => {
         // --version and --help may exit 0 or 1 depending on the CLI version.
         // Accept any exit as long as we got output.

--- a/src/cli-capabilities.ts
+++ b/src/cli-capabilities.ts
@@ -32,7 +32,8 @@ const DETECTION_TIMEOUT_MS = 5_000;
  * Env vars injected into every gemini child process.
  *
  * `GEMINI_CLI_NO_RELAUNCH=true` short-circuits @google/gemini-cli's runtime
- * self-relaunch (relaunchAppInChildProcess in packages/cli/src/utils/relaunch.ts),
+ * self-relaunch (`relaunchAppInChildProcess`, located at
+ * `packages/cli/src/utils/relaunch.ts` in v0.38.x of upstream),
  * which would otherwise spawn a second `node --max-old-space-size=<50% RAM>`
  * to inherit a larger heap. With one Node process per warm-pool slot we get a
  * flatter process tree, faster pool startup, and no shim-signal-propagation

--- a/src/gemini-runner.ts
+++ b/src/gemini-runner.ts
@@ -8,7 +8,7 @@ import { escape as escapeGlob, glob } from "glob";
 import pLimit from "p-limit";
 import { WarmProcessPool, type WarmProcess } from "./warm-pool.js";
 import { mcpLog } from "./logging.js";
-import { getCapabilities, buildBaseArgs } from "./cli-capabilities.js";
+import { getCapabilities, buildBaseArgs, GEMINI_CHILD_ENV_OVERRIDES } from "./cli-capabilities.js";
 import { spawnInGroup, killGroup } from "./process-group.js";
 
 export class GeminiOutputError extends Error {
@@ -182,6 +182,7 @@ if (POOL_ENABLED && !SETUP_MODE) {
     {
       HOME: process.env.HOME ?? "",
       PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+      ...GEMINI_CHILD_ENV_OVERRIDES,
     },
     effectiveStartupMs,
     GEMINI_BINARY
@@ -512,7 +513,7 @@ export function spawnGemini(
   onError: (err: Error) => void
 ): ChildProcess {
   const cp = spawnInGroup(GEMINI_BINARY, args, {
-    env: spawnOpts.env,
+    env: { ...spawnOpts.env, ...GEMINI_CHILD_ENV_OVERRIDES },
     cwd: spawnOpts.cwd,
     stdio: ["pipe", "pipe", "pipe"],
   });

--- a/src/process-group.ts
+++ b/src/process-group.ts
@@ -23,8 +23,8 @@ const POSIX = process.platform !== "win32";
 
 /**
  * Spawn a child as a process-group leader on POSIX so that the entire group
- * (immediate child + grandchildren spawned by an npm shim) can be signaled
- * together via {@link killGroup}.
+ * (CLI process + tool subprocesses or MCP subservers it may fork) can be
+ * signaled together via {@link killGroup}.
  *
  * The `detached` option is omitted from the parameter type because this helper
  * sets it unconditionally — letting a caller pass `detached: false` would

--- a/src/process-group.ts
+++ b/src/process-group.ts
@@ -1,24 +1,20 @@
 /**
  * Process-group spawn / signal helpers (issue #96).
  *
- * The npm-published `gemini` binary is a Node shim that re-spawns Node with
- * `--max-old-space-size=15890` to run the real CLI. So each warm-pool slot is
- * **two** OS processes: shim (immediate child) → real CLI (grandchild).
+ * Originally @google/gemini-cli ran as two Node processes per slot — the npm
+ * entry point would self-relaunch with `--max-old-space-size=<50% RAM>` for a
+ * larger heap, leaving the second process as a grandchild that survived
+ * `cp.kill(sig)` because the signal only reached the immediate child.
  *
- * `cp.kill(sig)` only signals the immediate child. The grandchild is
- * reparented to PID 1 and survives, leaking ~poolSize processes per server
- * lifecycle.
+ * Issue #98 eliminates the self-relaunch by setting `GEMINI_CLI_NO_RELAUNCH=true`
+ * in the spawn env (see `GEMINI_CHILD_ENV_OVERRIDES` in cli-capabilities.ts), so
+ * the warm-pool is now one Node process per slot.
  *
- * Fix on POSIX: spawn each child as a process-group leader (`detached: true`)
- * and signal the entire group via `process.kill(-pid, sig)`. The kernel then
- * delivers the signal to every member of the group, including grandchildren.
- *
- * Windows is intentionally left on single-PID kill behavior:
- *   • `detached: true` opens a visible console window per child on Windows
- *     because Node's `windowsHide` flag has no effect when `detached` is also
- *     set (nodejs/node#21825).
- *   • The PID-1 reparenting that creates the leak is POSIX-specific; Windows
- *     uses Job Objects with different lifecycle semantics.
+ * We still spawn as a process-group leader and signal the full group on
+ * shutdown: the CLI itself may fork tool subprocesses (shell tools, MCP
+ * subservers) that would otherwise be reparented to PID 1 if we only signaled
+ * the CLI's PID. POSIX-only — Windows uses Job Objects with different
+ * lifecycle semantics.
  */
 
 import { spawn, type SpawnOptions, type ChildProcess } from "node:child_process";

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import * as nodePath from "node:path";
 import { discoverGeminiBinary } from "./gemini-runner.js";
+import { GEMINI_CHILD_ENV_OVERRIDES } from "./cli-capabilities.js";
 
 const RESET = "\x1b[0m";
 const BOLD = "\x1b[1m";
@@ -237,7 +238,11 @@ async function installGeminiCli(): Promise<void> {
 async function checkAuth(binary: string): Promise<"ok" | "not-authenticated" | "timeout"> {
   return new Promise((resolve) => {
     const cp = spawn(binary, ["--prompt", "ping", "--output-format", "stream-json"], {
-      env: { HOME: process.env.HOME ?? "", PATH: process.env.PATH ?? "" },
+      env: {
+        HOME: process.env.HOME ?? "",
+        PATH: process.env.PATH ?? "",
+        ...GEMINI_CHILD_ENV_OVERRIDES,
+      },
       stdio: ["pipe", "pipe", "pipe"],
     });
     let stderr = "";

--- a/tests/cli-capabilities.test.ts
+++ b/tests/cli-capabilities.test.ts
@@ -225,6 +225,24 @@ Options:
       expect(execFileMock).toHaveBeenCalled();
     });
   });
+
+  // Issue #98: every gemini child must run with GEMINI_CLI_NO_RELAUNCH=true so the
+  // CLI's runtime self-relaunch (50%-of-RAM heap retry) is short-circuited and we
+  // get one Node process per slot instead of two.
+  describe("GEMINI_CLI_NO_RELAUNCH propagation", () => {
+    it("passes GEMINI_CLI_NO_RELAUNCH=true to execFile for every detection probe", async () => {
+      mockExecFile({
+        "--version": { stdout: "0.38.1\n" },
+        "--help": { stdout: "--yolo" },
+      });
+      await detectCapabilities("/usr/bin/gemini");
+      expect(execFileMock).toHaveBeenCalledTimes(2);
+      for (const call of execFileMock.mock.calls) {
+        const opts = call[2] as { env?: Record<string, string> };
+        expect(opts.env?.GEMINI_CLI_NO_RELAUNCH).toBe("true");
+      }
+    });
+  });
 });
 
 describe("buildBaseArgs", () => {

--- a/tests/gemini-runner-binary-discovery.test.ts
+++ b/tests/gemini-runner-binary-discovery.test.ts
@@ -129,6 +129,48 @@ describe("GEMINI_BINARY constant in spawn calls", () => {
       expect.any(Object)
     );
   });
+
+  // Issue #98: spawnGemini's cold-spawn path must inject GEMINI_CHILD_ENV_OVERRIDES
+  // into the child env so the upstream CLI's runtime self-relaunch is disabled.
+  // Warm pool covers the dominant path; this test guards the fallback.
+  it("merges GEMINI_CHILD_ENV_OVERRIDES into spawnGemini's child env", async () => {
+    process.env.GEMINI_BINARY = "/my/custom/gemini";
+    process.env.GEMINI_POOL_ENABLED = "0";
+
+    vi.doMock("node:child_process", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:child_process")>();
+      const mockSpawn = vi.fn().mockReturnValue({
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+        stdin: { end: vi.fn() },
+        on: vi.fn(),
+        kill: vi.fn(),
+        pid: 123,
+        exitCode: null,
+      });
+      return { ...actual, spawn: mockSpawn };
+    });
+
+    const mod = await import("../src/gemini-runner.js");
+    const { spawn } = await import("node:child_process");
+    const mockSpawn = spawn as unknown as ReturnType<typeof vi.fn>;
+
+    mod.spawnGemini(
+      ["--prompt", "test"],
+      { env: { HOME: "/home/test", PATH: "/usr/bin" }, timeout: 5000 },
+      () => {},
+      () => {},
+      () => {}
+    );
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const opts = mockSpawn.mock.calls[0][2] as { env?: Record<string, string> };
+    expect(opts.env).toMatchObject({
+      HOME: "/home/test",
+      PATH: "/usr/bin",
+      GEMINI_CLI_NO_RELAUNCH: "true",
+    });
+  });
 });
 
 describe("SETUP_MODE suppresses warm pool", () => {

--- a/tests/gemini-runner.test.ts
+++ b/tests/gemini-runner.test.ts
@@ -21,6 +21,7 @@ const _fallbackCaps = vi.hoisted(() => ({
 vi.mock("../src/cli-capabilities.js", () => ({
   getCapabilities: vi.fn().mockResolvedValue(_fallbackCaps),
   buildBaseArgs: vi.fn().mockImplementation(() => ["--yolo", "--output-format", "stream-json"]),
+  GEMINI_CHILD_ENV_OVERRIDES: { GEMINI_CLI_NO_RELAUNCH: "true" },
 }));
 
 import {

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -410,4 +410,45 @@ describe("runSetup", () => {
     expect(output).toContain("dist/index.js");
     writeSpy.mockRestore();
   });
+
+  // Issue #98: the auth-check spawn must set GEMINI_CLI_NO_RELAUNCH=true so the
+  // CLI doesn't re-exec itself for heap sizing during setup.
+  it("passes GEMINI_CLI_NO_RELAUNCH=true to the auth-check spawn", async () => {
+    vi.doMock("../src/gemini-runner.js", () => ({
+      discoverGeminiBinary: vi.fn().mockReturnValue("/usr/local/bin/gemini"),
+    }));
+    vi.doMock("node:fs", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs")>();
+      return { ...actual, existsSync: vi.fn().mockReturnValue(true) };
+    });
+
+    let authCheckOpts: { env?: Record<string, string> } | undefined;
+    vi.doMock("node:child_process", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:child_process")>();
+      const mockSpawn = vi.fn().mockImplementation(
+        (_cmd: string, args: string[], opts: { env?: Record<string, string> }) => {
+          if (args.includes("--prompt")) authCheckOpts = opts;
+          const cp = mockChildProcess();
+          const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+          (cp.on as ReturnType<typeof vi.fn>).mockImplementation(
+            (evt: string, cb: (...a: unknown[]) => void) => {
+              handlers[evt] = handlers[evt] ?? [];
+              handlers[evt].push(cb);
+            }
+          );
+          setTimeout(() => handlers["close"]?.forEach((cb) => cb(0, null)), 10);
+          return cp;
+        }
+      );
+      return { ...actual, spawn: mockSpawn };
+    });
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+    writeSpy.mockRestore();
+
+    expect(authCheckOpts).toBeDefined();
+    expect(authCheckOpts?.env?.GEMINI_CLI_NO_RELAUNCH).toBe("true");
+  });
 });

--- a/tests/tools/gemini-cancel.test.ts
+++ b/tests/tools/gemini-cancel.test.ts
@@ -44,8 +44,9 @@ describe("geminiCancel", () => {
     try {
       const result = await geminiCancel({ jobId: VALID_JOB_ID });
 
-      // Issue #96: cancel must signal the *group* (negative pid), not just the
-      // immediate child via cp.kill — the latter leaks the npm-shim grandchild.
+      // Issues #96/#98: cancel must signal the *group* (negative pid), not just
+      // the immediate child via cp.kill — the latter would not reach tool
+      // subprocesses the CLI may fork (shell tools, MCP subservers).
       expect(processKillSpy).toHaveBeenCalledWith(-4321, "SIGTERM");
       expect(mockKill).not.toHaveBeenCalled();
       expect(mockCancelJob).toHaveBeenCalledWith(VALID_JOB_ID);

--- a/tests/warm-pool.test.ts
+++ b/tests/warm-pool.test.ts
@@ -144,7 +144,7 @@ describe("WarmProcessPool", () => {
     );
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const opts = spawnMock.mock.calls[0][2] as { env?: Record<string, string> };
-    expect(opts.env).toEqual({
+    expect(opts.env).toMatchObject({
       HOME: "/home/test",
       PATH: "/bin",
       GEMINI_CLI_NO_RELAUNCH: "true",

--- a/tests/warm-pool.test.ts
+++ b/tests/warm-pool.test.ts
@@ -63,18 +63,27 @@ function makeMockCp(pid = 100): ChildProcess & {
 
 let spawnCalls: Array<ReturnType<typeof makeMockCp>> = [];
 
+const spawnMock = vi.hoisted(() =>
+  vi.fn((_cmd: string, _args: readonly string[], _opts: unknown) => {
+    // The test module reassigns spawnCalls in beforeEach; the closure captures
+    // the binding via the module-level `let`, not the value at hoist time.
+  }),
+);
+
 vi.mock("node:child_process", async (importOriginal) => {
   const original = await importOriginal<typeof import("node:child_process")>();
   return {
     ...original,
-    // Start mock PIDs at 100 — real children never get pid <= 1 and the new
-    // catastrophic-kill guard in killGroup refuses pid 0/1.
-    spawn: vi.fn(() => {
-      const cp = makeMockCp(100 + spawnCalls.length);
-      spawnCalls.push(cp);
-      return cp;
-    }),
+    spawn: spawnMock,
   };
+});
+
+// Start mock PIDs at 100 — real children never get pid <= 1 and the
+// catastrophic-kill guard in killGroup refuses pid 0/1.
+spawnMock.mockImplementation(() => {
+  const cp = makeMockCp(100 + spawnCalls.length);
+  spawnCalls.push(cp);
+  return cp;
 });
 
 // ── Import pool AFTER mock is installed ──────────────────────────────────────
@@ -121,6 +130,25 @@ describe("WarmProcessPool", () => {
   it("spawns poolSize processes on construction", () => {
     new WarmProcessPool(3, ["--yolo"], { HOME: "/home/test", PATH: "/bin" });
     expect(spawnCalls).toHaveLength(3);
+  });
+
+  // Issue #98: the env passed to the pool constructor must reach the spawn call
+  // so GEMINI_CLI_NO_RELAUNCH (set in gemini-runner.ts) actually disables the
+  // CLI's runtime self-relaunch.
+  it("forwards constructor env to spawn options", () => {
+    spawnMock.mockClear();
+    new WarmProcessPool(
+      1,
+      ["--yolo"],
+      { HOME: "/home/test", PATH: "/bin", GEMINI_CLI_NO_RELAUNCH: "true" },
+    );
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const opts = spawnMock.mock.calls[0][2] as { env?: Record<string, string> };
+    expect(opts.env).toEqual({
+      HOME: "/home/test",
+      PATH: "/bin",
+      GEMINI_CLI_NO_RELAUNCH: "true",
+    });
   });
 
   it("size property returns poolSize", () => {


### PR DESCRIPTION
## Summary

- Sets `GEMINI_CLI_NO_RELAUNCH=true` in the env of every gemini child process, eliminating the upstream CLI's runtime self-relaunch (`relaunchAppInChildProcess` in `packages/cli/src/utils/relaunch.ts`).
- One Node process per warm-pool slot instead of two — the `--max-old-space-size=<50% RAM>` re-exec hop is gone.
- Centralized as `GEMINI_CHILD_ENV_OVERRIDES` in `cli-capabilities.ts`, applied at all four spawn sites: `runCommand` (capability detection), warm-pool spawn, `spawnGemini` (cold one-shot), and `checkAuth` (setup wizard's auth probe).

## Why this differs from the issue body

The original issue (#98) proposed parsing the npm shim and spawning the real entrypoint directly with explicit Node flags. Investigation found there's no external shim — the relaunch is internal CLI logic, and upstream exposes a documented escape hatch (`GEMINI_CLI_NO_RELAUNCH=true`) which is the same flag the CLI itself uses on relaunched children to prevent infinite recursion. The escape-hatch contract is verified at v0.38.1 (installed) and v0.38.2 (latest).

**Trade-off:** the CLI runs at Node's default heap (~4 GB on 64-bit) instead of 50% of total RAM. Acceptable for our concurrency limits (`GEMINI_MAX_CONCURRENT=2` default). If a real prompt OOMs we revisit by passing `--max-old-space-size` explicitly via `process.execPath` spawn — but that's the more invasive original-issue approach we deferred.

## What's NOT changed

- `detached:true` / process-group kill (issue #96, commit `dd85fec`) stays — defends against tool subprocesses the gemini CLI itself may spawn.
- Sub-issues #97 (PDEATHSIG) and #99 (orphan reaper) — tracked separately.

## Test Plan

### Impact coverage audit
- [x] `git diff dd85fec...HEAD` reviewed — env-injection at four spawn sites, comment rewrites in `process-group.ts`, no behavior changes outside spawn env

### Documentation
- [x] `CLAUDE.md` "Env vars set on every gemini child (issue #98)" section reviewed — describes `GEMINI_CHILD_ENV_OVERRIDES`, contract verification at v0.38.1/0.38.2, manual `pgrep` integration step
- [x] `src/process-group.ts` head comment + `spawnInGroup` JSDoc reviewed — both reflect post-#98 reality (CLI-forked tool subprocesses, no npm-shim grandchildren)
- [x] `src/cli-capabilities.ts` `GEMINI_CHILD_ENV_OVERRIDES` docblock reviewed — accurate trade-off statement and version qualifier

### Functional scenarios

**Unit / build**
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npm test` 613/613 pass — includes new `tests/gemini-runner-binary-discovery.test.ts` test asserting `spawnGemini` cold-spawn env merge, plus existing `cli-capabilities`, `setup`, `warm-pool` propagation tests

**Hands-on integration (CLAUDE.md required scenarios — verified live against `dist/index.js` in the original review cycle; not re-run for the comment/test-only fix commit since no production code path changed)**
- [x] `ask-gemini` basic prompt with `wait:true` → `pong` returned
- [x] `gemini-reply` continuing the session → prior turn correctly recalled
- [x] `ask-gemini` async + `gemini-poll` → `done` status returned
- [x] `gemini-cancel` → `cancelled:true`, final status `cancelled`
- [x] `@file` reference (`@src/cli-capabilities.ts`) → CLI identified `GEMINI_CHILD_ENV_OVERRIDES`
- [x] Two concurrent `ask-gemini` calls → both completed (15, 9), distinct sessions

**Acceptance criterion (the actual one for #98)**
- [x] `ps --ppid <local-server-pid>` shows exactly **2 direct gemini children** (matches `GEMINI_POOL_SIZE`), zero relaunch grandchildren under the local server's subtree. PIDs turned over correctly between scenarios — pool replenishment intact.

## Review fixes (commit `a21b10e`)

Multi-agent review pipeline (code-reviewer + pr-test-analyzer + silent-failure-hunter + comment-analyzer + Gemini Pro 3) flagged six items, all comment/test/doc — no production-code changes:

- `src/process-group.ts:26` — `spawnInGroup` JSDoc said "grandchildren spawned by an npm shim"; reworded to match post-#98 file-head rationale.
- `tests/tools/gemini-cancel.test.ts:48` — same stale "npm-shim grandchild" comment.
- `CLAUDE.md` — "integration process-tree check fails — that's the canary" implied an automated check; reworded to describe the manual `pgrep` step honestly. Added v0.38.x version qualifier to upstream `relaunch.ts` path.
- `src/cli-capabilities.ts:35` — same v0.38.x qualifier on the docblock.
- `tests/warm-pool.test.ts:147` — `toEqual` → `toMatchObject` so the env assertion survives future overrides additions.
- `tests/gemini-runner-binary-discovery.test.ts` — new test guarding `spawnGemini` cold-spawn env merge (warm-pool path was already covered).

Skipped review findings (verified inapplicable): `setup.ts` `gemini-health` JSON.parse silent-fallback / `checkAuth` non-ENOENT classification / finally-block kill swallow — all pre-existing in `setup.ts`, not introduced by this PR. Defensive runtime warning in `WarmProcessPool` if override missing — YAGNI given existing call-site test coverage.

Closes #98