### PR TITLE
feat: orphan-prevention defense-in-depth (#97 + #99)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ Use `mcp__gemini-dev__*` tools (not `mcp__gemini__*` which hit the installed rel
 | `GEMINI_SKIP_DETECTION` | `0` | `1` = skip CLI version/flag detection at startup (use hardcoded fallback args) |
 | `GEMINI_MODELS` | (built-in list) | Comma-separated model IDs to override the default curated list for `gemini-list-models` |
 | `GEMINI_DISABLE_PDEATHSIG` | `0` | `1` = skip the `setpriv --pdeathsig TERM` wrapper around child spawns (Linux only). Escape hatch for the issue #97 kernel-level PDEATHSIG safety net; only the literal string `"1"` disables. |
+| `GEMINI_ORPHAN_REAPER` | `1` | `0` = disable the issue #99 startup sweep that reaps PID-1-orphaned `gemini --yolo --output-format stream-json` workers belonging to the current user. POSIX-only; no-op on Windows. |
 
 ## Env vars set on every gemini child (issue #98)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Use `mcp__gemini-dev__*` tools (not `mcp__gemini__*` which hit the installed rel
 | `GEMINI_SKIP_DETECTION` | `0` | `1` = skip CLI version/flag detection at startup (use hardcoded fallback args) |
 | `GEMINI_MODELS` | (built-in list) | Comma-separated model IDs to override the default curated list for `gemini-list-models` |
 | `GEMINI_DISABLE_PDEATHSIG` | `0` | `1` = skip the `setpriv --pdeathsig TERM` wrapper around child spawns (Linux only). Escape hatch for the issue #97 kernel-level PDEATHSIG safety net; only the literal string `"1"` disables. |
-| `GEMINI_ORPHAN_REAPER` | `1` | `0` = disable the issue #99 startup sweep that reaps PID-1-orphaned `gemini --yolo --output-format stream-json` workers belonging to the current user. POSIX-only; no-op on Windows. |
+| `GEMINI_ORPHAN_REAPER` | `1` | `0` = disable the issue #99 startup sweep that reaps orphaned `gemini --yolo --output-format stream-json` workers belonging to the current user (orphans whose parent is PID 1 *or* a root-owned subreaper ancestor — see `findLinuxSubreaperAncestors` for the WSL2/systemd-user/container case). POSIX-only; no-op on Windows. |
 
 ## Env vars set on every gemini child (issue #98)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ Use `mcp__gemini-dev__*` tools (not `mcp__gemini__*` which hit the installed rel
 | `GEMINI_JOB_GC_MS` | `60000` | Job garbage-collection sweep interval (ms) |
 | `GEMINI_SKIP_DETECTION` | `0` | `1` = skip CLI version/flag detection at startup (use hardcoded fallback args) |
 | `GEMINI_MODELS` | (built-in list) | Comma-separated model IDs to override the default curated list for `gemini-list-models` |
+| `GEMINI_DISABLE_PDEATHSIG` | `0` | `1` = skip the `setpriv --pdeathsig TERM` wrapper around child spawns (Linux only). Escape hatch for the issue #97 kernel-level PDEATHSIG safety net; only the literal string `"1"` disables. |
 
 ## Env vars set on every gemini child (issue #98)
 

--- a/src/gemini-runner.ts
+++ b/src/gemini-runner.ts
@@ -10,6 +10,7 @@ import { WarmProcessPool, type WarmProcess } from "./warm-pool.js";
 import { mcpLog } from "./logging.js";
 import { getCapabilities, buildBaseArgs, GEMINI_CHILD_ENV_OVERRIDES } from "./cli-capabilities.js";
 import { spawnInGroup, killGroup } from "./process-group.js";
+import { reapOrphans } from "./orphan-reaper.js";
 
 export class GeminiOutputError extends Error {
   constructor(message: string, public sanitizedMessage: string) {
@@ -164,6 +165,28 @@ export let warmPool: WarmProcessPool | null = null;
 // Suppress pool init during --setup: the pool would try to spawn gemini immediately,
 // producing ENOENT noise if gemini isn't installed yet (exactly the case --setup handles).
 const SETUP_MODE = process.argv.includes("--setup");
+
+// Issue #99 — orphan reaper. Fire-and-forget at module load, before pool init.
+// The strict PPID==1 filter inside reapOrphans ensures it cannot false-positive
+// on our own newborn pool members (their PPID is our PID, not 1), so this is
+// safe to run concurrently with the WarmProcessPool constructor below. Gated
+// by GEMINI_ORPHAN_REAPER (default on; set to "0" to disable).
+if (!SETUP_MODE && process.env.GEMINI_ORPHAN_REAPER !== "0") {
+  const log =
+    process.env.GEMINI_STRUCTURED_LOGS === "1"
+      ? (event: Record<string, unknown>) => {
+          process.stderr.write(JSON.stringify(event) + "\n");
+        }
+      : undefined;
+  void reapOrphans({
+    signature: ["--yolo", "--output-format", "stream-json"],
+    log,
+  }).catch((err: unknown) => {
+    process.stderr.write(
+      `[gemini-cli-mcp] orphan reaper failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  });
+}
 
 if (POOL_ENABLED && !SETUP_MODE) {
   const geminiConfigDir = nodePath.join(os.homedir(), ".config", "gemini");

--- a/src/gemini-runner.ts
+++ b/src/gemini-runner.ts
@@ -167,10 +167,11 @@ export let warmPool: WarmProcessPool | null = null;
 const SETUP_MODE = process.argv.includes("--setup");
 
 // Issue #99 — orphan reaper. Fire-and-forget at module load, before pool init.
-// The strict PPID==1 filter inside reapOrphans ensures it cannot false-positive
-// on our own newborn pool members (their PPID is our PID, not 1), so this is
-// safe to run concurrently with the WarmProcessPool constructor below. Gated
-// by GEMINI_ORPHAN_REAPER (default on; set to "0" to disable).
+// The strict subreaper-set membership filter inside reapOrphans ensures it
+// cannot false-positive on our own newborn pool members (their PPID is our
+// PID, never one of our root-owned ancestors), so this is safe to run
+// concurrently with the WarmProcessPool constructor below. Gated by
+// GEMINI_ORPHAN_REAPER (default on; set to "0" to disable).
 if (!SETUP_MODE && process.env.GEMINI_ORPHAN_REAPER !== "0") {
   const log =
     process.env.GEMINI_STRUCTURED_LOGS === "1"
@@ -181,11 +182,24 @@ if (!SETUP_MODE && process.env.GEMINI_ORPHAN_REAPER !== "0") {
   void reapOrphans({
     signature: ["--yolo", "--output-format", "stream-json"],
     log,
-  }).catch((err: unknown) => {
-    process.stderr.write(
-      `[gemini-cli-mcp] orphan reaper failed: ${err instanceof Error ? err.message : String(err)}\n`,
-    );
-  });
+  })
+    .then(({ reaped, failed }) => {
+      // failed > 0 means matched orphans we couldn't signal (e.g., EPERM,
+      // SIGKILL didn't take). Discarding the count would let an entirely
+      // failing reaper look identical to a clean run. Per-pid detail is in
+      // the structured log; this is the must-see headline.
+      if (failed > 0) {
+        process.stderr.write(
+          `[gemini-cli-mcp] orphan reaper: ${reaped} reaped, ${failed} failed ` +
+            `(enable GEMINI_STRUCTURED_LOGS=1 for per-pid detail)\n`,
+        );
+      }
+    })
+    .catch((err: unknown) => {
+      process.stderr.write(
+        `[gemini-cli-mcp] orphan reaper failed: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    });
 }
 
 if (POOL_ENABLED && !SETUP_MODE) {

--- a/src/orphan-reaper.ts
+++ b/src/orphan-reaper.ts
@@ -1,0 +1,288 @@
+/**
+ * Startup orphan reaper (issue #99).
+ *
+ * Defense-in-depth for the warm-pool process leak (epic #96). Even with
+ * process-group kill (#96/#100) and shim elimination (#98/#102), pre-existing
+ * orphans from older MCP server versions and any future regression in the
+ * kill path do not self-clean. On startup, before the warm pool spawns, we
+ * sweep the process table for `gemini --yolo --output-format stream-json`
+ * processes whose parent is PID 1 (orphaned) and whose owner UID matches us,
+ * SIGTERM them, wait, then SIGKILL survivors.
+ *
+ * The strict PPID==1 filter is what makes module-load fire-and-forget safe:
+ * our own newborn pool members have PPID == our PID until we ourselves die,
+ * so the reaper cannot false-positive on them even when running concurrently
+ * with pool startup.
+ *
+ * POSIX-only. Linux uses /proc; macOS uses `ps -A`. Windows: no-op (no
+ * PID-1 reparenting; the underlying leak is POSIX-specific anyway).
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { execFile } from "node:child_process";
+
+export interface OrphanProcess {
+  pid: number;
+  ppid: number;
+  uid: number;
+  cmdline: string;
+  ageSeconds: number | null;
+}
+
+export interface ReapOpts {
+  signature: readonly string[];
+  log?: (event: Record<string, unknown>) => void;
+  getuid?: () => number;
+  /** Override for tests. If omitted, picks a default by `platform`. */
+  listProcesses?: () => Promise<OrphanProcess[]>;
+  /** Override for tests. Defaults to {@link defaultKill}. */
+  kill?: (pid: number, signal: NodeJS.Signals | 0) => boolean;
+  /** Time between SIGTERM sweep and SIGKILL escalation. Default 2000. */
+  forceKillDelayMs?: number;
+  /** Override for tests. Defaults to `process.platform`. */
+  platform?: NodeJS.Platform;
+}
+
+export interface ReapResult {
+  reaped: number;
+  failed: number;
+}
+
+/** Default `kill` impl: returns true on success, false on any failure. */
+function defaultKill(pid: number, signal: NodeJS.Signals | 0): boolean {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Returns the platform-default process source, or `null` if unsupported. */
+function defaultListProcesses(platform: NodeJS.Platform): (() => Promise<OrphanProcess[]>) | null {
+  if (platform === "linux") return listLinuxProcesses;
+  if (platform === "darwin") return listMacosProcesses;
+  return null;
+}
+
+function matchesSignature(cmdline: string, signature: readonly string[]): boolean {
+  if (signature.length === 0) return false;
+  // The joined signature is what we expect to see verbatim in cmdline. Real
+  // gemini-CLI cmdlines have these args in order separated by single spaces.
+  return cmdline.includes(signature.join(" "));
+}
+
+export async function reapOrphans(opts: ReapOpts): Promise<ReapResult> {
+  const platform = opts.platform ?? process.platform;
+  const list = opts.listProcesses ?? defaultListProcesses(platform);
+  if (list === null) return { reaped: 0, failed: 0 };
+
+  const myUid = (opts.getuid ?? process.getuid?.bind(process) ?? (() => -1))();
+  const kill = opts.kill ?? defaultKill;
+  const log = opts.log ?? (() => {});
+  const forceKillDelayMs = opts.forceKillDelayMs ?? 2000;
+
+  let candidates: OrphanProcess[];
+  try {
+    candidates = await list();
+  } catch {
+    // Adapter failure (filesystem race, ps not on PATH, etc.) — silently no-op.
+    return { reaped: 0, failed: 0 };
+  }
+
+  // Filter — strict PPID==1 + UID + cmdline + catastrophic-kill guard.
+  const matches = candidates.filter(
+    (p) =>
+      p.pid > 1 &&
+      p.ppid === 1 &&
+      p.uid === myUid &&
+      matchesSignature(p.cmdline, opts.signature),
+  );
+
+  if (matches.length === 0) return { reaped: 0, failed: 0 };
+
+  // Phase 1 — SIGTERM all. Per-pid errors are silently absorbed via tryKill.
+  // We track which pids we successfully signaled so we know whom to re-check.
+  const signaled = new Map<number, OrphanProcess>();
+  for (const p of matches) {
+    const ok = tryKill(kill, p.pid, "SIGTERM");
+    log({
+      ts: new Date().toISOString(),
+      event: "orphan_reaped",
+      pid: p.pid,
+      age_seconds: p.ageSeconds,
+      cmdline: p.cmdline.slice(0, 200),
+      signal: "SIGTERM",
+      ok,
+    });
+    if (ok) signaled.set(p.pid, p);
+  }
+
+  // Phase 2 — wait, then check for survivors and SIGKILL them.
+  if (forceKillDelayMs > 0) await sleep(forceKillDelayMs);
+
+  let reaped = 0;
+  let failed = matches.length - signaled.size; // SIGTERM-failed pids count as failed
+
+  for (const p of signaled.values()) {
+    const stillAlive = tryKill(kill, p.pid, 0);
+    if (!stillAlive) {
+      reaped++;
+      continue;
+    }
+    const killed = tryKill(kill, p.pid, "SIGKILL");
+    log({
+      ts: new Date().toISOString(),
+      event: "orphan_reaped",
+      pid: p.pid,
+      age_seconds: p.ageSeconds,
+      cmdline: p.cmdline.slice(0, 200),
+      signal: "SIGKILL",
+      ok: killed,
+    });
+    if (killed) reaped++;
+    else failed++;
+  }
+
+  return { reaped, failed };
+}
+
+function tryKill(
+  kill: (pid: number, signal: NodeJS.Signals | 0) => boolean,
+  pid: number,
+  signal: NodeJS.Signals | 0,
+): boolean {
+  try {
+    return kill(pid, signal);
+  } catch {
+    return false;
+  }
+}
+
+// ── Linux /proc adapter ──────────────────────────────────────────────────────
+
+export async function listLinuxProcesses(): Promise<OrphanProcess[]> {
+  const uptimeSeconds = readUptimeSeconds();
+  const clockTicks = 100; // sysconf(_SC_CLK_TCK) — 100 on every modern Linux
+
+  let entries: string[];
+  try {
+    entries = readdirSync("/proc");
+  } catch {
+    return [];
+  }
+
+  const out: OrphanProcess[] = [];
+  for (const name of entries) {
+    if (!/^\d+$/.test(name)) continue;
+    const pid = Number(name);
+    try {
+      const proc = readLinuxProcess(pid, uptimeSeconds, clockTicks);
+      if (proc !== null) out.push(proc);
+    } catch {
+      // Process disappeared mid-sweep, or unreadable — skip silently.
+    }
+  }
+  return out;
+}
+
+function readUptimeSeconds(): number | null {
+  try {
+    const raw = readFileSync("/proc/uptime", "utf8");
+    const first = raw.split(/\s+/)[0];
+    const n = Number.parseFloat(first ?? "");
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+function readLinuxProcess(
+  pid: number,
+  uptimeSeconds: number | null,
+  clockTicks: number,
+): OrphanProcess | null {
+  // /proc/[pid]/stat: pid (comm) state ppid pgrp ... starttime ...
+  // The `comm` field can contain spaces and parens, so we anchor on the LAST
+  // `)` and parse the space-separated fields that follow it.
+  const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+  const lastParen = stat.lastIndexOf(")");
+  if (lastParen < 0) return null;
+  const after = stat.slice(lastParen + 1).trim().split(/\s+/);
+  // After the comm, fields are: state(0) ppid(1) pgrp(2) ... starttime(19)
+  const ppid = Number.parseInt(after[1] ?? "", 10);
+  const starttimeTicks = Number.parseInt(after[19] ?? "", 10);
+  if (!Number.isFinite(ppid)) return null;
+
+  // /proc/[pid]/status: line "Uid:\treal\teffective\tsavedset\tfs"
+  const status = readFileSync(`/proc/${pid}/status`, "utf8");
+  const uidMatch = /^Uid:\s+(\d+)/m.exec(status);
+  const uid = uidMatch ? Number.parseInt(uidMatch[1] ?? "", 10) : NaN;
+  if (!Number.isFinite(uid)) return null;
+
+  // /proc/[pid]/cmdline: NUL-separated, NUL-terminated args.
+  const cmdlineRaw = readFileSync(`/proc/${pid}/cmdline`, "utf8");
+  const cmdline = cmdlineRaw.replace(/\0+$/, "").replace(/\0/g, " ");
+
+  let ageSeconds: number | null = null;
+  if (uptimeSeconds !== null && Number.isFinite(starttimeTicks)) {
+    const startSeconds = starttimeTicks / clockTicks;
+    const age = uptimeSeconds - startSeconds;
+    ageSeconds = age >= 0 ? Math.round(age) : null;
+  }
+
+  return { pid, ppid, uid, cmdline, ageSeconds };
+}
+
+// ── macOS ps adapter ─────────────────────────────────────────────────────────
+
+export async function listMacosProcesses(): Promise<OrphanProcess[]> {
+  // `=` suppresses headers; the trailing `command=` captures the full command
+  // line including spaces (must be the last column for that to work).
+  const stdout = await new Promise<string>((resolve) => {
+    execFile(
+      "ps",
+      ["-A", "-o", "pid=,ppid=,uid=,etime=,command="],
+      { timeout: 2000, maxBuffer: 4 * 1024 * 1024 },
+      (err, out) => {
+        if (err) resolve("");
+        else resolve(out);
+      },
+    );
+  });
+
+  const out: OrphanProcess[] = [];
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "") continue;
+    // Parse leading 4 numeric/dashed columns + remainder as command.
+    const m = /^\s*(\d+)\s+(\d+)\s+(\d+)\s+([\d:\-]+)\s+(.*)$/.exec(line);
+    if (m === null) continue;
+    const pid = Number.parseInt(m[1] ?? "", 10);
+    const ppid = Number.parseInt(m[2] ?? "", 10);
+    const uid = Number.parseInt(m[3] ?? "", 10);
+    const ageSeconds = parseEtime(m[4] ?? "");
+    const cmdline = (m[5] ?? "").trim();
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid) || !Number.isFinite(uid)) continue;
+    out.push({ pid, ppid, uid, cmdline, ageSeconds });
+  }
+  return out;
+}
+
+/**
+ * Parses a `ps -o etime` value to seconds. Format is `[[DD-]HH:]MM:SS`.
+ * Examples: "02:30" → 150, "1:23:45" → 5025, "1-00:00:00" → 86400.
+ */
+function parseEtime(etime: string): number | null {
+  const m = /^(?:(\d+)-)?(?:(\d+):)?(\d+):(\d+)$/.exec(etime);
+  if (m === null) return null;
+  const days = m[1] ? Number.parseInt(m[1], 10) : 0;
+  const hours = m[2] ? Number.parseInt(m[2], 10) : 0;
+  const minutes = Number.parseInt(m[3] ?? "0", 10);
+  const seconds = Number.parseInt(m[4] ?? "0", 10);
+  return days * 86400 + hours * 3600 + minutes * 60 + seconds;
+}

--- a/src/orphan-reaper.ts
+++ b/src/orphan-reaper.ts
@@ -6,13 +6,14 @@
  * orphans from older MCP server versions and any future regression in the
  * kill path do not self-clean. On startup, before the warm pool spawns, we
  * sweep the process table for `gemini --yolo --output-format stream-json`
- * processes whose parent is PID 1 (orphaned) and whose owner UID matches us,
- * SIGTERM them, wait, then SIGKILL survivors.
+ * processes whose parent is in the subreaper set (PID 1 ∪ root-owned
+ * ancestors of our PID — see `findLinuxSubreaperAncestors`) and whose owner
+ * UID matches us, SIGTERM them, wait, then SIGKILL survivors.
  *
- * The strict PPID==1 filter is what makes module-load fire-and-forget safe:
- * our own newborn pool members have PPID == our PID until we ourselves die,
- * so the reaper cannot false-positive on them even when running concurrently
- * with pool startup.
+ * The strict subreaper-set membership filter is what makes module-load
+ * fire-and-forget safe: our own newborn pool members have PPID == our PID,
+ * never one of our root-owned ancestors, so the reaper cannot false-positive
+ * on them even when running concurrently with pool startup.
  *
  * POSIX-only. Linux uses /proc; macOS uses `ps -A`. Windows: no-op (no
  * PID-1 reparenting; the underlying leak is POSIX-specific anyway).
@@ -46,7 +47,7 @@ export interface ReapOpts {
    * (root-owned ancestors of process.pid on Linux). Override for tests or
    * environments where automatic discovery is wrong.
    *
-   * Why this is not just {1}: since Linux 2.6.36 a process can register as
+   * Why this is not just {1}: since Linux 3.4 a process can register as
    * a "child subreaper" via prctl(PR_SET_CHILD_SUBREAPER); the kernel then
    * reparents orphaned descendants of that process to the subreaper instead
    * of PID 1. WSL2's per-namespace `/init`, systemd-user, container
@@ -95,9 +96,12 @@ function matchesSignature(cmdline: string, signature: readonly string[]): boolea
  * to via the subreaper mechanism. PID 1 is always added.
  *
  * Non-root ancestors (user shell, the host that spawned us) are deliberately
- * skipped: orphans can't be reparented to them by definition (they're not
- * subreapers of root processes), and including them would risk killing
- * sibling MCP-server warm-pool members spawned by the same shell.
+ * skipped. Root-ownership is a practical proxy for "system-level subreaper":
+ * any process can call prctl(PR_SET_CHILD_SUBREAPER) regardless of UID, but
+ * the subreapers we actually want to handle (systemd PID 1, WSL2 /init,
+ * systemd-user@<root>, container runtimes) are root-owned in practice.
+ * Including user-owned ancestors would risk killing sibling MCP-server
+ * warm-pool members spawned by the same shell or process tree.
  *
  * Returns a set with `1` always present; on non-Linux returns just `{1}`.
  */
@@ -157,8 +161,20 @@ export async function reapOrphans(opts: ReapOpts): Promise<ReapResult> {
   let candidates: OrphanProcess[];
   try {
     candidates = await list();
-  } catch {
-    // Adapter failure (filesystem race, ps not on PATH, etc.) — silently no-op.
+  } catch (err: unknown) {
+    // Adapter failure (filesystem race, ps not on PATH, etc.) — no-op the
+    // sweep but surface the failure. A fully-broken reaper that returns 0/0
+    // would be invisible; the sweep is a safety net and silent breakage of
+    // a safety net defeats the point.
+    const msg = err instanceof Error ? err.message : String(err);
+    log({
+      ts: new Date().toISOString(),
+      event: "orphan_reaper_list_failed",
+      error: msg,
+    });
+    process.stderr.write(
+      `[gemini-cli-mcp] orphan reaper: process list failed (${msg}) — sweep skipped\n`,
+    );
     return { reaped: 0, failed: 0 };
   }
 
@@ -194,25 +210,57 @@ export async function reapOrphans(opts: ReapOpts): Promise<ReapResult> {
     if (ok) signaled.set(p.pid, p);
   }
 
-  // Phase 2 — wait, then check for survivors and SIGKILL them.
+  // Phase 2 — wait, then re-verify each survivor before SIGKILL.
   if (forceKillDelayMs > 0) await sleep(forceKillDelayMs);
 
   let reaped = 0;
   let failed = matches.length - signaled.size; // SIGTERM-failed pids count as failed
 
+  // Re-fetch the process table so SIGKILL only fires on PIDs that still
+  // match the original UID + cmdline signature. Without this, the kernel
+  // could have reused a SIGTERMed PID during the wait window for an
+  // unrelated same-user process, and our SIGKILL would hit the wrong
+  // target. Re-listing is cheap (small table on a startup-time sweep) and
+  // the safety win is unrecoverable if we get it wrong.
+  let surviving: Map<number, OrphanProcess>;
+  try {
+    const refreshed = await list();
+    surviving = new Map(
+      refreshed
+        .filter(
+          (p) =>
+            signaled.has(p.pid) &&
+            p.uid === myUid &&
+            matchesSignature(p.cmdline, opts.signature),
+        )
+        .map((p) => [p.pid, p]),
+    );
+  } catch {
+    // Re-list failed mid-sweep — skip SIGKILL escalation entirely. SIGTERM
+    // is the typical happy path for the gemini CLI; stragglers (if any) are
+    // caught on the next startup sweep. Counting all signaled as `reaped`
+    // would overstate; counting all as `failed` would understate. Report
+    // the SIGTERM ack count, which is the only thing we can verify.
+    return { reaped: signaled.size, failed };
+  }
+
   for (const p of signaled.values()) {
-    const stillAlive = tryKill(kill, p.pid, 0);
-    if (!stillAlive) {
+    if (!surviving.has(p.pid)) {
+      // Either the process is gone (SIGTERM worked — happy path) or its
+      // PID was reused by an unrelated process (race we just dodged). In
+      // both cases, do NOT escalate to SIGKILL. Counting as reaped is
+      // accurate for the happy path and conservative for the race.
       reaped++;
       continue;
     }
+    const survivor = surviving.get(p.pid)!;
     const killed = tryKill(kill, p.pid, "SIGKILL");
     log({
       ts: new Date().toISOString(),
       event: "orphan_reaped",
       pid: p.pid,
-      age_seconds: p.ageSeconds,
-      cmdline: p.cmdline.slice(0, 200),
+      age_seconds: survivor.ageSeconds,
+      cmdline: survivor.cmdline.slice(0, 200),
       signal: "SIGKILL",
       ok: killed,
     });

--- a/src/orphan-reaper.ts
+++ b/src/orphan-reaper.ts
@@ -380,7 +380,7 @@ export async function listMacosProcesses(): Promise<OrphanProcess[]> {
     const trimmed = line.trim();
     if (trimmed === "") continue;
     // Parse leading 4 numeric/dashed columns + remainder as command.
-    const m = /^\s*(\d+)\s+(\d+)\s+(\d+)\s+([\d:\-]+)\s+(.*)$/.exec(line);
+    const m = /^\s*(\d+)\s+(\d+)\s+(\d+)\s+([\d:-]+)\s+(.*)$/.exec(line);
     if (m === null) continue;
     const pid = Number.parseInt(m[1] ?? "", 10);
     const ppid = Number.parseInt(m[2] ?? "", 10);

--- a/src/orphan-reaper.ts
+++ b/src/orphan-reaper.ts
@@ -41,6 +41,19 @@ export interface ReapOpts {
   forceKillDelayMs?: number;
   /** Override for tests. Defaults to `process.platform`. */
   platform?: NodeJS.Platform;
+  /**
+   * PIDs that the kernel may reparent our orphans to. Defaults to {1} ∪
+   * (root-owned ancestors of process.pid on Linux). Override for tests or
+   * environments where automatic discovery is wrong.
+   *
+   * Why this is not just {1}: since Linux 2.6.36 a process can register as
+   * a "child subreaper" via prctl(PR_SET_CHILD_SUBREAPER); the kernel then
+   * reparents orphaned descendants of that process to the subreaper instead
+   * of PID 1. WSL2's per-namespace `/init`, systemd-user, container
+   * runtimes, and some shells all do this. So orphans can land at any
+   * subreaper above us — not just PID 1.
+   */
+  subreaperPids?: ReadonlySet<number>;
 }
 
 export interface ReapResult {
@@ -76,6 +89,61 @@ function matchesSignature(cmdline: string, signature: readonly string[]): boolea
   return cmdline.includes(signature.join(" "));
 }
 
+/**
+ * Walk our own ancestor chain on Linux and collect PIDs whose owner UID is 0
+ * (root). Those are the candidates the kernel may have reparented our orphans
+ * to via the subreaper mechanism. PID 1 is always added.
+ *
+ * Non-root ancestors (user shell, the host that spawned us) are deliberately
+ * skipped: orphans can't be reparented to them by definition (they're not
+ * subreapers of root processes), and including them would risk killing
+ * sibling MCP-server warm-pool members spawned by the same shell.
+ *
+ * Returns a set with `1` always present; on non-Linux returns just `{1}`.
+ */
+function findLinuxSubreaperAncestors(): Set<number> {
+  const result = new Set<number>([1]);
+  if (process.platform !== "linux") return result;
+
+  let cursor = process.pid;
+  // Bounded by the depth of any plausible Linux process tree; the guard is
+  // belt-and-suspenders against /proc returning a stale or malformed PPID.
+  for (let i = 0; i < 64; i++) {
+    let parent: number;
+    let parentUid: number;
+    try {
+      const stat = readFileSync(`/proc/${cursor}/stat`, "utf8");
+      const lastParen = stat.lastIndexOf(")");
+      if (lastParen < 0) break;
+      const after = stat.slice(lastParen + 1).trim().split(/\s+/);
+      parent = Number.parseInt(after[1] ?? "", 10);
+      if (!Number.isFinite(parent) || parent <= 1) {
+        if (parent === 1) result.add(1);
+        break;
+      }
+      const status = readFileSync(`/proc/${parent}/status`, "utf8");
+      const m = /^Uid:\s+(\d+)/m.exec(status);
+      parentUid = m ? Number.parseInt(m[1] ?? "", 10) : NaN;
+    } catch {
+      break;
+    }
+    if (parentUid === 0) result.add(parent);
+    cursor = parent;
+  }
+  return result;
+}
+
+let _subreaperCache: Set<number> | null = null;
+function getDefaultSubreaperPids(): ReadonlySet<number> {
+  if (_subreaperCache === null) _subreaperCache = findLinuxSubreaperAncestors();
+  return _subreaperCache;
+}
+
+/** @internal Test-only: clear the cached subreaper set so the next call re-walks /proc. */
+export function _resetSubreaperCacheForTest(): void {
+  _subreaperCache = null;
+}
+
 export async function reapOrphans(opts: ReapOpts): Promise<ReapResult> {
   const platform = opts.platform ?? process.platform;
   const list = opts.listProcesses ?? defaultListProcesses(platform);
@@ -94,11 +162,15 @@ export async function reapOrphans(opts: ReapOpts): Promise<ReapResult> {
     return { reaped: 0, failed: 0 };
   }
 
-  // Filter — strict PPID==1 + UID + cmdline + catastrophic-kill guard.
+  // Filter — PPID is in the subreaper set (PID 1 + root-owned ancestors of us)
+  // + UID + cmdline + catastrophic-kill guard. The strict subreaper-set check
+  // is what makes module-load fire-and-forget safe: our own newborn pool
+  // members have PPID == our PID, never one of our root-owned ancestors.
+  const subreaperPids = opts.subreaperPids ?? getDefaultSubreaperPids();
   const matches = candidates.filter(
     (p) =>
       p.pid > 1 &&
-      p.ppid === 1 &&
+      subreaperPids.has(p.ppid) &&
       p.uid === myUid &&
       matchesSignature(p.cmdline, opts.signature),
   );

--- a/src/process-group.ts
+++ b/src/process-group.ts
@@ -33,17 +33,34 @@ const POSIX = process.platform !== "win32";
 // (graceful exit, SIGKILL, OOM, hard crash), the kernel synchronously
 // delivers SIGTERM to the child — no userspace shutdown handler required.
 //
-// Probed once at module load. Sync probe is fine: `setpriv --version` runs
-// in <5ms on every Linux distro that ships it, and `spawnInGroup` itself is
-// sync, so there's no convenient async hook anyway. Probe failure (timeout,
-// ENOENT, non-Linux) yields `null` and the wrapper falls through cleanly.
+// Probed once at module load. Sync probe is fine: it runs in <5ms on every
+// Linux distro that ships setpriv, and `spawnInGroup` itself is sync. We
+// probe the actual `--pdeathsig` invocation against `/bin/true` (not just
+// `--version`) because Ubuntu 18.04 / CentOS 7 ship util-linux 2.31 which
+// has the binary but lacks the flag — `--version` would falsely succeed
+// and every subsequent spawn would fail with "unrecognized option".
 
 function detectSetpriv(): string | null {
   if (process.platform !== "linux") return null;
   try {
-    execFileSync("setpriv", ["--version"], { timeout: 200, stdio: "ignore" });
+    execFileSync("setpriv", ["--pdeathsig", "TERM", "--", "true"], {
+      timeout: 200,
+      stdio: "ignore",
+    });
     return "setpriv";
-  } catch {
+  } catch (err: unknown) {
+    const code = (err as { code?: string } | null)?.code;
+    // ENOENT = setpriv not installed (expected fallback). Anything else
+    // (EACCES, ETIMEDOUT, non-zero exit from --pdeathsig unsupported, etc.)
+    // silently disables the entire issue #97 PDEATHSIG safety net. Surface
+    // it on stderr so users can debug rather than wonder why orphan workers
+    // survived a parent crash. Suppress when the user explicitly opted out.
+    if (code !== "ENOENT" && process.env.GEMINI_DISABLE_PDEATHSIG !== "1") {
+      process.stderr.write(
+        `[gemini-cli-mcp] setpriv --pdeathsig probe failed (${code ?? "non-zero exit"}): ` +
+          `PDEATHSIG safety net disabled. Set GEMINI_DISABLE_PDEATHSIG=1 to silence.\n`,
+      );
+    }
     return null;
   }
 }

--- a/src/process-group.ts
+++ b/src/process-group.ts
@@ -15,11 +15,60 @@
  * subservers) that would otherwise be reparented to PID 1 if we only signaled
  * the CLI's PID. POSIX-only — Windows uses Job Objects with different
  * lifecycle semantics.
+ *
+ * Issue #97 layers a kernel-level safety net on top: on Linux we wrap the
+ * spawn with `setpriv --pdeathsig TERM --` so the kernel delivers SIGTERM to
+ * the child the moment its parent dies. That covers the failure modes the
+ * graceful shutdown path can't (SIGKILL, OOM, hard crash).
  */
 
-import { spawn, type SpawnOptions, type ChildProcess } from "node:child_process";
+import { spawn, execFileSync, type SpawnOptions, type ChildProcess } from "node:child_process";
 
 const POSIX = process.platform !== "win32";
+
+// ── PR_SET_PDEATHSIG via setpriv (issue #97) ─────────────────────────────────
+//
+// `setpriv --pdeathsig TERM --` (util-linux ≥ 2.33) sets the kernel
+// PR_SET_PDEATHSIG flag on the child. When the parent dies for any reason
+// (graceful exit, SIGKILL, OOM, hard crash), the kernel synchronously
+// delivers SIGTERM to the child — no userspace shutdown handler required.
+//
+// Probed once at module load. Sync probe is fine: `setpriv --version` runs
+// in <5ms on every Linux distro that ships it, and `spawnInGroup` itself is
+// sync, so there's no convenient async hook anyway. Probe failure (timeout,
+// ENOENT, non-Linux) yields `null` and the wrapper falls through cleanly.
+
+function detectSetpriv(): string | null {
+  if (process.platform !== "linux") return null;
+  try {
+    execFileSync("setpriv", ["--version"], { timeout: 200, stdio: "ignore" });
+    return "setpriv";
+  } catch {
+    return null;
+  }
+}
+
+let setprivPath: string | null = detectSetpriv();
+
+/**
+ * @internal Test-only: override the cached setpriv probe result.
+ * Pass a string to simulate "setpriv installed at this path", `null` to
+ * simulate "setpriv not installed", or `undefined` to re-run the real probe.
+ */
+export function _setSetprivPathForTest(path: string | null | undefined): void {
+  setprivPath = path === undefined ? detectSetpriv() : path;
+}
+
+function shouldWrapWithSetpriv(): boolean {
+  // Linux-only (no PR_SET_PDEATHSIG on macOS / BSD; Windows uses Job Objects).
+  // The escape hatch matches the codebase convention: only the literal "1"
+  // disables — anything else (incl. "true", "yes", empty) is treated as opt-in.
+  return (
+    setprivPath !== null &&
+    process.platform === "linux" &&
+    process.env.GEMINI_DISABLE_PDEATHSIG !== "1"
+  );
+}
 
 /**
  * Spawn a child as a process-group leader on POSIX so that the entire group
@@ -39,6 +88,16 @@ export function spawnInGroup(
   args: readonly string[],
   options: Omit<SpawnOptions, "detached">,
 ): ChildProcess {
+  if (shouldWrapWithSetpriv()) {
+    // The setpriv shim becomes the group leader and the real CLI inherits the
+    // group, so killGroup() still reaches both. The shim is ~one extra exec
+    // layer (negligible vs. the CLI's multi-second startup).
+    return spawn(
+      setprivPath!,
+      ["--pdeathsig", "TERM", "--", command, ...args],
+      { ...options, detached: POSIX },
+    );
+  }
   return spawn(command, args, { ...options, detached: POSIX });
 }
 

--- a/tests/gemini-runner-binary-discovery.test.ts
+++ b/tests/gemini-runner-binary-discovery.test.ts
@@ -202,3 +202,52 @@ describe("SETUP_MODE suppresses warm pool", () => {
     }
   });
 });
+
+describe("GEMINI_ORPHAN_REAPER kill-switch (issue #99)", () => {
+  // The reaper is fire-and-forget at module load. Both the documented kill
+  // switch (GEMINI_ORPHAN_REAPER=0) and SETUP_MODE must short-circuit it
+  // before reapOrphans() is called — a refactor that accidentally inverts
+  // either guard would otherwise leave no test signal.
+
+  const originalEnv = process.env.GEMINI_ORPHAN_REAPER;
+  const reapSpy = vi.hoisted(() => vi.fn().mockResolvedValue({ reaped: 0, failed: 0 }));
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.GEMINI_BINARY;
+    delete process.env.GEMINI_POOL_ENABLED;
+    process.env.GEMINI_POOL_ENABLED = "0"; // avoid warm-pool spawn side effects
+    reapSpy.mockClear();
+    vi.doMock("../src/orphan-reaper.js", () => ({
+      reapOrphans: reapSpy,
+      _resetSubreaperCacheForTest: () => {},
+    }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("../src/orphan-reaper.js");
+    delete process.env.GEMINI_POOL_ENABLED;
+    if (originalEnv === undefined) delete process.env.GEMINI_ORPHAN_REAPER;
+    else process.env.GEMINI_ORPHAN_REAPER = originalEnv;
+  });
+
+  it("calls reapOrphans by default (env unset)", async () => {
+    delete process.env.GEMINI_ORPHAN_REAPER;
+    await import("../src/gemini-runner.js");
+    expect(reapSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call reapOrphans when GEMINI_ORPHAN_REAPER=0", async () => {
+    process.env.GEMINI_ORPHAN_REAPER = "0";
+    await import("../src/gemini-runner.js");
+    expect(reapSpy).not.toHaveBeenCalled();
+  });
+
+  it("still calls reapOrphans for non-'0' values (only literal '0' disables)", async () => {
+    // Matches the codebase convention for env-var booleans (cf. the
+    // GEMINI_DISABLE_PDEATHSIG '1'-only contract in process-group.ts).
+    process.env.GEMINI_ORPHAN_REAPER = "false"; // not "0"
+    await import("../src/gemini-runner.js");
+    expect(reapSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/gemini-runner-binary-discovery.test.ts
+++ b/tests/gemini-runner-binary-discovery.test.ts
@@ -81,15 +81,24 @@ describe("discoverGeminiBinary", () => {
 });
 
 describe("GEMINI_BINARY constant in spawn calls", () => {
+  // These tests assert the exact binary `spawn` receives. Issue #97's setpriv
+  // wrap reshapes that on Linux (spawn is called with "setpriv" and the binary
+  // is in args). Disabling the wrap here keeps these tests focused on binary
+  // discovery — separate suite (process-group.test.ts) covers the wrap itself.
+  const originalDisablePdeathsig = process.env.GEMINI_DISABLE_PDEATHSIG;
+
   beforeEach(() => {
     vi.resetModules();
     delete process.env.GEMINI_BINARY;
     delete process.env.GEMINI_POOL_ENABLED;
+    process.env.GEMINI_DISABLE_PDEATHSIG = "1";
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     vi.doUnmock("node:child_process");
+    if (originalDisablePdeathsig === undefined) delete process.env.GEMINI_DISABLE_PDEATHSIG;
+    else process.env.GEMINI_DISABLE_PDEATHSIG = originalDisablePdeathsig;
   });
 
   it("uses GEMINI_BINARY env var in module-level constant (spawn receives it)", async () => {

--- a/tests/orphan-reaper.test.ts
+++ b/tests/orphan-reaper.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Unit tests for the startup orphan reaper (issue #99).
+ *
+ * The reaper has two layers:
+ *   1. Platform adapters (`listLinuxProcesses` / `listMacosProcesses`) — read
+ *      the OS process table and yield a normalized {pid, ppid, uid, cmdline,
+ *      ageSeconds}[].
+ *   2. Business logic (`reapOrphans`) — filter by PPID==1 + UID + cmdline
+ *      signature, SIGTERM all matches, wait, SIGKILL survivors, emit
+ *      structured-log events.
+ *
+ * The business-logic tests inject a fake `listProcesses` and `kill` so they
+ * never touch the real OS. The adapter tests mock `node:fs` (for /proc) and
+ * `node:child_process` (for `ps`) at the module level.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Module-level mocks for adapter tests ─────────────────────────────────────
+
+const fsMock = vi.hoisted(() => ({
+  readdirSync: vi.fn<(path: string) => string[]>(),
+  readFileSync: vi.fn<(path: string, opts?: unknown) => string | Buffer>(),
+}));
+const execFileMock = vi.hoisted(() =>
+  vi.fn<(
+    cmd: string,
+    args: string[],
+    opts: unknown,
+    cb: (err: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void,
+  ) => void>(),
+);
+
+vi.mock("node:fs", () => ({
+  readdirSync: fsMock.readdirSync,
+  readFileSync: fsMock.readFileSync,
+}));
+vi.mock("node:child_process", () => ({
+  execFile: execFileMock,
+}));
+
+beforeEach(() => {
+  fsMock.readdirSync.mockReset();
+  fsMock.readFileSync.mockReset();
+  execFileMock.mockReset();
+});
+
+// ── reapOrphans business logic ───────────────────────────────────────────────
+
+describe("reapOrphans (business logic)", () => {
+  it("returns {reaped:0,failed:0} when no candidate processes are found", async () => {
+    const { reapOrphans } = await import("../src/orphan-reaper.js");
+    const result = await reapOrphans({
+      signature: ["--yolo"],
+      listProcesses: async () => [],
+      getuid: () => 1000,
+      kill: () => true,
+    });
+    expect(result).toEqual({ reaped: 0, failed: 0 });
+  });
+
+  it("filters out processes with PPID !== 1 (only orphans are reaped)", async () => {
+    // A live MCP server's own pool member has PPID == its own PID, never 1.
+    // The strict PPID==1 filter is what makes module-load fire-and-forget safe.
+    const { reapOrphans } = await import("../src/orphan-reaper.js");
+    const killSpy = vi.fn(() => true);
+    const result = await reapOrphans({
+      signature: ["--yolo"],
+      listProcesses: async () => [
+        { pid: 1234, ppid: 999, uid: 1000, cmdline: "gemini --yolo", ageSeconds: 60 },
+      ],
+      getuid: () => 1000,
+      kill: killSpy,
+      forceKillDelayMs: 0,
+    });
+    expect(result).toEqual({ reaped: 0, failed: 0 });
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it("filters out processes belonging to other users (UID mismatch — never cross-user kill)", async () => {
+    const { reapOrphans } = await import("../src/orphan-reaper.js");
+    const killSpy = vi.fn(() => true);
+    const result = await reapOrphans({
+      signature: ["--yolo"],
+      listProcesses: async () => [
+        { pid: 1234, ppid: 1, uid: 2000, cmdline: "gemini --yolo", ageSeconds: 60 },
+      ],
+      getuid: () => 1000,
+      kill: killSpy,
+      forceKillDelayMs: 0,
+    });
+    expect(result).toEqual({ reaped: 0, failed: 0 });
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it("filters out processes whose cmdline does not contain the signature", async () => {
+    const { reapOrphans } = await import("../src/orphan-reaper.js");
+    const killSpy = vi.fn(() => true);
+    const result = await reapOrphans({
+      signature: ["--yolo", "--output-format", "stream-json"],
+      listProcesses: async () => [
+        { pid: 1234, ppid: 1, uid: 1000, cmdline: "node server.js --yolo", ageSeconds: 60 },
+      ],
+      getuid: () => 1000,
+      kill: killSpy,
+      forceKillDelayMs: 0,
+    });
+    // cmdline lacks "--output-format" and "stream-json" — does not match.
+    expect(result).toEqual({ reaped: 0, failed: 0 });
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it("refuses to signal pid <= 1 even if filter logic somehow yielded one", async () => {
+    // Catastrophic-kill guard mirrored from killGroup() in process-group.ts —
+    // process.kill(0/1, sig) would hit every process the user can reach.
+    const { reapOrphans } = await import("../src/orphan-reaper.js");
+    const killSpy = vi.fn(() => true);
+    await reapOrphans({
+      signature: ["--yolo"],
+      listProcesses: async () => [
+        { pid: 1, ppid: 1, uid: 1000, cmdline: "gemini --yolo", ageSeconds: 0 },
+        { pid: 0, ppid: 1, uid: 1000, cmdline: "gemini --yolo", ageSeconds: 0 },
+      ],
+      getuid: () => 1000,
+      kill: killSpy,
+      forceKillDelayMs: 0,
+    });
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it("SIGTERMs matching orphans, then re-checks and SIGKILLs survivors", async () => {
+    const { reapOrphans } = await import("../src/orphan-reaper.js");
+    // Calls in order:
+    //   kill(1234, SIGTERM) → true (sent successfully)
+    //   kill(5678, SIGTERM) → true
+    //   kill(1234, 0)       → false (gone — well-behaved)
+    //   kill(5678, 0)       → true  (survivor)
+    //   kill(5678, SIGKILL) → true  (forcibly killed)
+    const callLog: Array<[number, NodeJS.Signals | 0]> = [];
+    const kill = vi.fn((pid: number, signal: NodeJS.Signals | 0) => {
+      callLog.push([pid, signal]);
+      if (signal === "SIGTERM") return true;
+      if (signal === 0) return pid === 5678; // 1234 already gone
+      return true; // SIGKILL succeeded
+    });
+    const result = await reapOrphans({
+      signature: ["--yolo"],
+      listProcesses: async () => [
+        { pid: 1234, ppid: 1, uid: 1000, cmdline: "gemini --yolo", ageSeconds: 60 },
+        { pid: 5678, ppid: 1, uid: 1000, cmdline: "gemini --yolo", ageSeconds: 90 },
+      ],
+      getuid: () => 1000,
+      kill,
+      forceKillDelayMs: 0,
+    });
+    expect(result).toEqual({ reaped: 2, failed: 0 });
+    expect(callLog).toEqual([
+      [1234, "SIGTERM"],
+      [5678, "SIGTERM"],
+      [1234, 0],
+      [5678, 0],
+      [5678, "SIGKILL"],
+    ]);
+  });
+
+  it("counts a process as failed when SIGKILL also fails", async () => {
+    const { reapOrphans } = await import("../src/orphan-reaper.js");
+    const kill = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === "SIGTERM") return true;
+      if (signal === 0) return true;     // still alive after wait
+      if (signal === "SIGKILL") return false; // SIGKILL also failed (perms / weird)
+      return false;
+    });
+    const result = await reapOrphans({
+      signature: ["--yolo"],
+      listProcesses: async () => [
+        { pid: 1234, ppid: 1, uid: 1000, cmdline: "gemini --yolo", ageSeconds: 60 },
+      ],
+      getuid: () => 1000,
+      kill,
+      forceKillDelayMs: 0,
+    });
+    expect(result).toEqual({ reaped: 0, failed: 1 });
+  });
+
+  it("emits structured-log events per signal sent (SIGTERM and SIGKILL)", async () => {
+    const { reapOrphans } = await import("../src/orphan-reaper.js");
+    const events: Array<Record<string, unknown>> = [];
+    const log = (e: Record<string, unknown>) => events.push(e);
+    const kill = (_pid: number, signal: NodeJS.Signals | 0) => {
+      if (signal === 0) return true;  // survivor → triggers SIGKILL
+      return true;
+    };
+    await reapOrphans({
+      signature: ["--yolo"],
+      listProcesses: async () => [
+        { pid: 1234, ppid: 1, uid: 1000, cmdline: "gemini --yolo --output-format stream-json", ageSeconds: 120 },
+      ],
+      getuid: () => 1000,
+      kill,
+      log,
+      forceKillDelayMs: 0,
+    });
+    // One event for SIGTERM + one for SIGKILL escalation.
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      event: "orphan_reaped",
+      pid: 1234,
+      signal: "SIGTERM",
+      age_seconds: 120,
+    });
+    expect(events[1]).toMatchObject({
+      event: "orphan_reaped",
+      pid: 1234,
+      signal: "SIGKILL",
+      age_seconds: 120,
+    });
+    // Each event has an ISO timestamp and the cmdline (truncated for safety).
+    for (const e of events) {
+      expect(typeof e.ts).toBe("string");
+      expect(e.cmdline).toContain("gemini --yolo");
+    }
+  });
+
+  it("absorbs per-pid errors silently (one bad pid does not abort the sweep)", async () => {
+    const { reapOrphans } = await import("../src/orphan-reaper.js");
+    const kill = vi.fn((pid: number, _signal: NodeJS.Signals | 0) => {
+      if (pid === 1234) throw Object.assign(new Error("EPERM"), { code: "EPERM" });
+      return true;
+    });
+    const result = await reapOrphans({
+      signature: ["--yolo"],
+      listProcesses: async () => [
+        { pid: 1234, ppid: 1, uid: 1000, cmdline: "gemini --yolo", ageSeconds: 60 },
+        { pid: 5678, ppid: 1, uid: 1000, cmdline: "gemini --yolo", ageSeconds: 90 },
+      ],
+      getuid: () => 1000,
+      kill,
+      forceKillDelayMs: 0,
+    });
+    // 1234 fails (kill threw on SIGTERM); 5678 succeeds.
+    expect(result.reaped).toBe(1);
+    expect(result.failed).toBe(1);
+  });
+
+  it("returns {reaped:0,failed:0} on unsupported platforms (no listProcesses default)", async () => {
+    const { reapOrphans } = await import("../src/orphan-reaper.js");
+    // platform "win32" has no default listProcesses — must no-op.
+    const result = await reapOrphans({
+      signature: ["--yolo"],
+      getuid: () => 1000,
+      kill: () => true,
+      platform: "win32",
+    });
+    expect(result).toEqual({ reaped: 0, failed: 0 });
+  });
+});
+
+// ── listLinuxProcesses adapter (mocked /proc) ────────────────────────────────
+
+describe("listLinuxProcesses (Linux /proc adapter)", () => {
+  it("reads /proc, parses stat/status/cmdline, computes ageSeconds from uptime", async () => {
+    fsMock.readdirSync.mockImplementation((path) => {
+      if (path === "/proc") return ["1", "2", "1234", "5678", "self", "cpuinfo", "abc"];
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    fsMock.readFileSync.mockImplementation((path) => {
+      const p = String(path);
+      if (p === "/proc/uptime") return "12345.67 9876.54";
+      if (p === "/proc/1234/stat") {
+        // Field 4 = ppid (1), field 22 = starttime in clock ticks since boot.
+        // `(comm)` may contain spaces — we parse the LAST `)` to skip the comm.
+        // 100 Hz default clock; starttime 1000 → process started 10s after boot
+        // → age = 12345.67 - 10 = 12335.67 seconds (~3.4 hours).
+        return `1234 (gemini) S 1 1234 1234 0 -1 4194304 0 0 0 0 0 0 0 0 20 0 1 0 1000 0 0 18446744073709551615`;
+      }
+      if (p === "/proc/1234/status") {
+        return "Name:\tgemini\nUid:\t1000\t1000\t1000\t1000\nGid:\t1000\t1000\t1000\t1000\n";
+      }
+      if (p === "/proc/1234/cmdline") {
+        // NUL-separated, NUL-terminated
+        return "gemini\0--yolo\0--output-format\0stream-json\0";
+      }
+      // 5678 has a parenthesized comm with spaces — parsing must handle it.
+      if (p === "/proc/5678/stat") {
+        return `5678 (node (gemini)) S 999 5678 5678 0 -1 4194304 0 0 0 0 0 0 0 0 20 0 1 0 2000 0 0`;
+      }
+      if (p === "/proc/5678/status") {
+        return "Name:\tnode\nUid:\t1000\t1000\t1000\t1000\n";
+      }
+      if (p === "/proc/5678/cmdline") {
+        return "node\0/usr/bin/gemini\0--yolo\0";
+      }
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    const { listLinuxProcesses } = await import("../src/orphan-reaper.js");
+    const procs = await listLinuxProcesses();
+    expect(procs).toEqual([
+      {
+        pid: 1234,
+        ppid: 1,
+        uid: 1000,
+        cmdline: "gemini --yolo --output-format stream-json",
+        ageSeconds: expect.any(Number),
+      },
+      {
+        pid: 5678,
+        ppid: 999,
+        uid: 1000,
+        cmdline: "node /usr/bin/gemini --yolo",
+        ageSeconds: expect.any(Number),
+      },
+    ]);
+    // Sanity: 1234 started 10s after boot, uptime 12345.67s → age ≈ 12335s
+    expect(procs[0].ageSeconds).toBeGreaterThan(12000);
+    expect(procs[0].ageSeconds).toBeLessThan(12500);
+  });
+
+  it("skips /proc entries that disappear mid-sweep (race with reaping)", async () => {
+    fsMock.readdirSync.mockReturnValue(["1234", "5678"]);
+    fsMock.readFileSync.mockImplementation((path) => {
+      const p = String(path);
+      if (p === "/proc/uptime") return "100.0 50.0";
+      if (p.startsWith("/proc/1234/")) {
+        // 1234 died between readdir and readFileSync — ENOENT
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      }
+      if (p === "/proc/5678/stat") return "5678 (gemini) S 1 5678 5678 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 50";
+      if (p === "/proc/5678/status") return "Uid:\t1000\t1000\t1000\t1000\n";
+      if (p === "/proc/5678/cmdline") return "gemini\0--yolo\0";
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    const { listLinuxProcesses } = await import("../src/orphan-reaper.js");
+    const procs = await listLinuxProcesses();
+    // 1234 silently skipped; 5678 returned.
+    expect(procs).toHaveLength(1);
+    expect(procs[0].pid).toBe(5678);
+  });
+
+  it("skips non-numeric /proc entries like 'self', 'cpuinfo', 'mounts'", async () => {
+    fsMock.readdirSync.mockReturnValue(["self", "cpuinfo", "mounts", "1", "abc123"]);
+    fsMock.readFileSync.mockImplementation((path) => {
+      const p = String(path);
+      if (p === "/proc/uptime") return "100.0 50.0";
+      if (p === "/proc/1/stat") return "1 (init) S 0 1 1 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 0";
+      if (p === "/proc/1/status") return "Uid:\t0\t0\t0\t0\n";
+      if (p === "/proc/1/cmdline") return "init\0";
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    const { listLinuxProcesses } = await import("../src/orphan-reaper.js");
+    const procs = await listLinuxProcesses();
+    // Only the numeric "1" is processed.
+    expect(procs).toHaveLength(1);
+    expect(procs[0].pid).toBe(1);
+  });
+});
+
+// ── listMacosProcesses adapter (mocked execFile ps) ──────────────────────────
+
+describe("listMacosProcesses (macOS ps adapter)", () => {
+  it("parses `ps -A` output into normalized OrphanProcess[]", async () => {
+    execFileMock.mockImplementation((cmd, _args, _opts, cb) => {
+      expect(cmd).toBe("ps");
+      // Format: pid ppid uid etime command...
+      const stdout = [
+        "    1     0     0   01-12:00:00 /sbin/launchd",
+        " 1234     1  1000      02:30 /usr/local/bin/gemini --yolo --output-format stream-json",
+        " 5678   999  1000   1-00:00:00 node /usr/bin/gemini",
+        "",
+      ].join("\n");
+      cb(null, stdout, "");
+    });
+    const { listMacosProcesses } = await import("../src/orphan-reaper.js");
+    const procs = await listMacosProcesses();
+    expect(procs).toHaveLength(3);
+    expect(procs[1]).toEqual({
+      pid: 1234,
+      ppid: 1,
+      uid: 1000,
+      cmdline: "/usr/local/bin/gemini --yolo --output-format stream-json",
+      ageSeconds: expect.any(Number),
+    });
+    // etime "02:30" = 2m30s = 150 seconds
+    expect(procs[1].ageSeconds).toBe(150);
+    // etime "1-00:00:00" = 1 day = 86400 seconds
+    expect(procs[2].ageSeconds).toBe(86400);
+    // etime "01-12:00:00" = 1d 12h = 86400 + 43200 = 129600 seconds
+    expect(procs[0].ageSeconds).toBe(129600);
+  });
+
+  it("returns [] when ps fails (e.g. permission denied)", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(Object.assign(new Error("EACCES"), { code: "EACCES" }), "", "");
+    });
+    const { listMacosProcesses } = await import("../src/orphan-reaper.js");
+    const procs = await listMacosProcesses();
+    expect(procs).toEqual([]);
+  });
+
+  it("skips lines that don't match the expected pid/ppid/uid/etime/command shape", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      const stdout = [
+        "garbage line",
+        "  PID  PPID   UID    ELAPSED COMMAND",  // header-like (would be filtered if `=` format misused)
+        " 1234     1  1000      02:30 /usr/bin/gemini",
+        "",
+      ].join("\n");
+      cb(null, stdout, "");
+    });
+    const { listMacosProcesses } = await import("../src/orphan-reaper.js");
+    const procs = await listMacosProcesses();
+    expect(procs).toHaveLength(1);
+    expect(procs[0].pid).toBe(1234);
+  });
+});

--- a/tests/orphan-reaper.test.ts
+++ b/tests/orphan-reaper.test.ts
@@ -254,6 +254,70 @@ describe("reapOrphans (business logic)", () => {
     });
     expect(result).toEqual({ reaped: 0, failed: 0 });
   });
+
+  it("reaps orphans whose PPID is a subreaper ancestor (e.g. WSL2 /init), not just PID 1", async () => {
+    // WSL2 (and systemd-user / containers) install per-namespace subreapers
+    // via prctl(PR_SET_CHILD_SUBREAPER). Orphans get reparented to the
+    // nearest subreaper, NOT PID 1. Discovered during integration testing
+    // on WSL2 where orphans landed at PID 748339 (the user-namespace init).
+    const { reapOrphans } = await import("../src/orphan-reaper.js");
+    const killSpy = vi.fn(() => true);
+    const result = await reapOrphans({
+      signature: ["--yolo"],
+      // Caller injects the discovered subreaper set; in production this is
+      // computed by walking /proc/self's parent chain for root-owned PIDs.
+      subreaperPids: new Set<number>([1, 748339, 748338]),
+      listProcesses: async () => [
+        { pid: 875306, ppid: 748339, uid: 1000, cmdline: "node gemini --yolo", ageSeconds: 30 },
+      ],
+      getuid: () => 1000,
+      kill: killSpy,
+      forceKillDelayMs: 0,
+    });
+    expect(result.reaped).toBe(1);
+    expect(killSpy).toHaveBeenCalledWith(875306, "SIGTERM");
+  });
+
+  it("does NOT reap a process whose PPID is a non-subreaper ancestor (sibling MCP server safety)", async () => {
+    // A second MCP server's warm-pool members have PPID == that-MCP's PID,
+    // which is user-owned (not root-owned), so it's NOT in the subreaper set.
+    // The filter must spare them.
+    const { reapOrphans } = await import("../src/orphan-reaper.js");
+    const killSpy = vi.fn(() => true);
+    const result = await reapOrphans({
+      signature: ["--yolo"],
+      subreaperPids: new Set<number>([1, 748339]), // only root-owned ancestors
+      listProcesses: async () => [
+        // PPID 858414 is some live user-owned process (e.g., another MCP server)
+        { pid: 999999, ppid: 858414, uid: 1000, cmdline: "gemini --yolo", ageSeconds: 5 },
+      ],
+      getuid: () => 1000,
+      kill: killSpy,
+      forceKillDelayMs: 0,
+    });
+    expect(result).toEqual({ reaped: 0, failed: 0 });
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it("default subreaperPids set always contains PID 1 (regression guard for non-WSL2 systems)", async () => {
+    // On bare Linux without subreapers, orphans go to PID 1. The default
+    // subreaper-set discovery must always seed {1}, otherwise we'd miss
+    // every orphan on a vanilla system.
+    const { reapOrphans } = await import("../src/orphan-reaper.js");
+    const killSpy = vi.fn(() => true);
+    const result = await reapOrphans({
+      signature: ["--yolo"],
+      // No explicit subreaperPids — fall through to platform default.
+      listProcesses: async () => [
+        { pid: 1234, ppid: 1, uid: 1000, cmdline: "gemini --yolo", ageSeconds: 60 },
+      ],
+      getuid: () => 1000,
+      kill: killSpy,
+      forceKillDelayMs: 0,
+    });
+    expect(result.reaped).toBe(1);
+    expect(killSpy).toHaveBeenCalledWith(1234, "SIGTERM");
+  });
 });
 
 // ── listLinuxProcesses adapter (mocked /proc) ────────────────────────────────

--- a/tests/orphan-reaper.test.ts
+++ b/tests/orphan-reaper.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetSubreaperCacheForTest, type OrphanProcess } from "../src/orphan-reaper.js";
 
 // ── Module-level mocks for adapter tests ─────────────────────────────────────
 
@@ -43,6 +44,15 @@ beforeEach(() => {
   fsMock.readdirSync.mockReset();
   fsMock.readFileSync.mockReset();
   execFileMock.mockReset();
+});
+
+afterEach(() => {
+  // Module-level subreaper cache populates on first call to
+  // getDefaultSubreaperPids() and persists for the rest of the process.
+  // Without this reset, tests that omit `subreaperPids` (e.g. the default
+  // regression guard) would see whatever the first such test cached,
+  // making them order-dependent.
+  _resetSubreaperCacheForTest();
 });
 
 // ── reapOrphans business logic ───────────────────────────────────────────────
@@ -128,27 +138,33 @@ describe("reapOrphans (business logic)", () => {
     expect(killSpy).not.toHaveBeenCalled();
   });
 
-  it("SIGTERMs matching orphans, then re-checks and SIGKILLs survivors", async () => {
+  it("SIGTERMs matching orphans, then re-lists and SIGKILLs survivors", async () => {
     const { reapOrphans } = await import("../src/orphan-reaper.js");
     // Calls in order:
-    //   kill(1234, SIGTERM) → true (sent successfully)
+    //   listProcesses() → [1234, 5678]
+    //   kill(1234, SIGTERM) → true
     //   kill(5678, SIGTERM) → true
-    //   kill(1234, 0)       → false (gone — well-behaved)
-    //   kill(5678, 0)       → true  (survivor)
-    //   kill(5678, SIGKILL) → true  (forcibly killed)
+    //   listProcesses() → [5678 only]  (1234 died from SIGTERM, well-behaved)
+    //   kill(5678, SIGKILL) → true
+    const orphan = (pid: number, age: number): OrphanProcess => ({
+      pid,
+      ppid: 1,
+      uid: 1000,
+      cmdline: "gemini --yolo",
+      ageSeconds: age,
+    });
+    const listProcesses = vi
+      .fn<() => Promise<OrphanProcess[]>>()
+      .mockResolvedValueOnce([orphan(1234, 60), orphan(5678, 90)])
+      .mockResolvedValueOnce([orphan(5678, 92)]); // only 5678 survives
     const callLog: Array<[number, NodeJS.Signals | 0]> = [];
     const kill = vi.fn((pid: number, signal: NodeJS.Signals | 0) => {
       callLog.push([pid, signal]);
-      if (signal === "SIGTERM") return true;
-      if (signal === 0) return pid === 5678; // 1234 already gone
-      return true; // SIGKILL succeeded
+      return true;
     });
     const result = await reapOrphans({
       signature: ["--yolo"],
-      listProcesses: async () => [
-        { pid: 1234, ppid: 1, uid: 1000, cmdline: "gemini --yolo", ageSeconds: 60 },
-        { pid: 5678, ppid: 1, uid: 1000, cmdline: "gemini --yolo", ageSeconds: 90 },
-      ],
+      listProcesses,
       getuid: () => 1000,
       kill,
       forceKillDelayMs: 0,
@@ -157,25 +173,32 @@ describe("reapOrphans (business logic)", () => {
     expect(callLog).toEqual([
       [1234, "SIGTERM"],
       [5678, "SIGTERM"],
-      [1234, 0],
-      [5678, 0],
       [5678, "SIGKILL"],
     ]);
+    expect(listProcesses).toHaveBeenCalledTimes(2);
   });
 
   it("counts a process as failed when SIGKILL also fails", async () => {
     const { reapOrphans } = await import("../src/orphan-reaper.js");
+    const orphan: OrphanProcess = {
+      pid: 1234,
+      ppid: 1,
+      uid: 1000,
+      cmdline: "gemini --yolo",
+      ageSeconds: 60,
+    };
+    const listProcesses = vi
+      .fn<() => Promise<OrphanProcess[]>>()
+      .mockResolvedValueOnce([orphan])
+      .mockResolvedValueOnce([orphan]); // still there → SIGKILL escalation
     const kill = vi.fn((_pid: number, signal: NodeJS.Signals | 0) => {
       if (signal === "SIGTERM") return true;
-      if (signal === 0) return true;     // still alive after wait
-      if (signal === "SIGKILL") return false; // SIGKILL also failed (perms / weird)
+      if (signal === "SIGKILL") return false; // perms / weird kernel state
       return false;
     });
     const result = await reapOrphans({
       signature: ["--yolo"],
-      listProcesses: async () => [
-        { pid: 1234, ppid: 1, uid: 1000, cmdline: "gemini --yolo", ageSeconds: 60 },
-      ],
+      listProcesses,
       getuid: () => 1000,
       kill,
       forceKillDelayMs: 0,
@@ -187,17 +210,22 @@ describe("reapOrphans (business logic)", () => {
     const { reapOrphans } = await import("../src/orphan-reaper.js");
     const events: Array<Record<string, unknown>> = [];
     const log = (e: Record<string, unknown>) => events.push(e);
-    const kill = (_pid: number, signal: NodeJS.Signals | 0) => {
-      if (signal === 0) return true;  // survivor → triggers SIGKILL
-      return true;
+    const orphan: OrphanProcess = {
+      pid: 1234,
+      ppid: 1,
+      uid: 1000,
+      cmdline: "gemini --yolo --output-format stream-json",
+      ageSeconds: 120,
     };
+    const listProcesses = vi
+      .fn<() => Promise<OrphanProcess[]>>()
+      .mockResolvedValueOnce([orphan])
+      .mockResolvedValueOnce([orphan]); // survivor → triggers SIGKILL
     await reapOrphans({
       signature: ["--yolo"],
-      listProcesses: async () => [
-        { pid: 1234, ppid: 1, uid: 1000, cmdline: "gemini --yolo --output-format stream-json", ageSeconds: 120 },
-      ],
+      listProcesses,
       getuid: () => 1000,
-      kill,
+      kill: () => true,
       log,
       forceKillDelayMs: 0,
     });
@@ -241,6 +269,89 @@ describe("reapOrphans (business logic)", () => {
     // 1234 fails (kill threw on SIGTERM); 5678 succeeds.
     expect(result.reaped).toBe(1);
     expect(result.failed).toBe(1);
+  });
+
+  it("does NOT SIGKILL a PID whose cmdline no longer matches (PID-reuse race protection)", async () => {
+    // Between SIGTERM and SIGKILL the kernel may reuse a freed PID for an
+    // unrelated same-user process. The re-list step must filter by signature
+    // again, not just liveness, so SIGKILL never lands on the wrong target.
+    const { reapOrphans } = await import("../src/orphan-reaper.js");
+    const killSpy = vi.fn(() => true);
+    const listProcesses = vi
+      .fn<() => Promise<OrphanProcess[]>>()
+      .mockResolvedValueOnce([
+        { pid: 4242, ppid: 1, uid: 1000, cmdline: "gemini --yolo --output-format stream-json", ageSeconds: 60 },
+      ])
+      // Re-list: same PID is now an unrelated process (kernel reused 4242)
+      .mockResolvedValueOnce([
+        { pid: 4242, ppid: 1234, uid: 1000, cmdline: "vim notes.md", ageSeconds: 0 },
+      ]);
+    const result = await reapOrphans({
+      signature: ["--yolo", "--output-format", "stream-json"],
+      listProcesses,
+      getuid: () => 1000,
+      kill: killSpy,
+      forceKillDelayMs: 0,
+    });
+    // SIGTERM goes out (we believed it was the orphan at the time), but
+    // SIGKILL must not fire on the recycled PID.
+    expect(killSpy).toHaveBeenCalledWith(4242, "SIGTERM");
+    expect(killSpy).not.toHaveBeenCalledWith(4242, "SIGKILL");
+    // Counted as reaped — either the original orphan died (best case) or we
+    // dodged the race; both are correct outcomes for the user.
+    expect(result).toEqual({ reaped: 1, failed: 0 });
+  });
+
+  it("logs adapter failure to stderr + structured log when listProcesses() rejects", async () => {
+    // A fully-broken reaper that returned {0,0} silently would be invisible.
+    // The sweep is a safety net; silent breakage of a safety net defeats it.
+    const { reapOrphans } = await import("../src/orphan-reaper.js");
+    const events: Array<Record<string, unknown>> = [];
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const result = await reapOrphans({
+        signature: ["--yolo"],
+        listProcesses: async () => {
+          throw Object.assign(new Error("EACCES /proc"), { code: "EACCES" });
+        },
+        getuid: () => 1000,
+        kill: () => true,
+        log: (e) => events.push(e),
+      });
+      expect(result).toEqual({ reaped: 0, failed: 0 });
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({ event: "orphan_reaper_list_failed" });
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+      const written = String(stderrSpy.mock.calls[0]?.[0] ?? "");
+      expect(written).toContain("orphan reaper");
+      expect(written).toContain("EACCES");
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it("skips SIGKILL escalation when the re-list call fails (conservative fallback)", async () => {
+    // If the re-list itself fails, we cannot safely SIGKILL — we'd be
+    // guessing about cmdline match. The sweep returns based on SIGTERM
+    // success and the next startup catches any stragglers.
+    const { reapOrphans } = await import("../src/orphan-reaper.js");
+    const killSpy = vi.fn(() => true);
+    const listProcesses = vi
+      .fn<() => Promise<OrphanProcess[]>>()
+      .mockResolvedValueOnce([
+        { pid: 1234, ppid: 1, uid: 1000, cmdline: "gemini --yolo", ageSeconds: 60 },
+      ])
+      .mockRejectedValueOnce(new Error("re-list failed"));
+    const result = await reapOrphans({
+      signature: ["--yolo"],
+      listProcesses,
+      getuid: () => 1000,
+      kill: killSpy,
+      forceKillDelayMs: 0,
+    });
+    expect(killSpy).toHaveBeenCalledWith(1234, "SIGTERM");
+    expect(killSpy).not.toHaveBeenCalledWith(1234, "SIGKILL");
+    expect(result).toEqual({ reaped: 1, failed: 0 });
   });
 
   it("returns {reaped:0,failed:0} on unsupported platforms (no listProcesses default)", async () => {

--- a/tests/process-group.test.ts
+++ b/tests/process-group.test.ts
@@ -221,6 +221,9 @@ describe("process-group helpers (Windows simulated)", () => {
     spawnInGroup("cmd", ["/c", "echo hi"], { stdio: "ignore" });
     expect(lastSpawnArgs).not.toBeNull();
     expect(lastSpawnArgs!.options.detached).toBe(false);
+    // On Windows the setpriv wrapper must never apply — process group / pdeathsig
+    // are POSIX-only concepts and `setpriv` would not exist anyway.
+    expect(lastSpawnArgs!.command).toBe("cmd");
   });
 
   it("killGroup falls back to cp.kill(signal) on Windows", async () => {
@@ -256,3 +259,100 @@ describe("process-group helpers (Windows simulated)", () => {
     }
   });
 });
+
+// ── PR_SET_PDEATHSIG wrapper (issue #97) ─────────────────────────────────────
+//
+// On Linux, `setpriv --pdeathsig TERM -- <cmd>` makes the kernel deliver
+// SIGTERM to the child the moment its parent dies — the safety net that runs
+// even when our JS shutdown handler doesn't (SIGKILL, OOM, hard crash).
+//
+// `_setSetprivPathForTest` is a test-only export that overrides the
+// module-level cached probe so we can deterministically simulate
+// "setpriv installed" / "setpriv missing" without relying on the host.
+
+describe("spawnInGroup setpriv pdeathsig wrap (Linux)", () => {
+  const originalDisable = process.env.GEMINI_DISABLE_PDEATHSIG;
+
+  beforeEach(() => {
+    delete process.env.GEMINI_DISABLE_PDEATHSIG;
+  });
+
+  afterEach(async () => {
+    if (originalDisable === undefined) delete process.env.GEMINI_DISABLE_PDEATHSIG;
+    else process.env.GEMINI_DISABLE_PDEATHSIG = originalDisable;
+    // Restore real probe result for any subsequent suite.
+    const { _setSetprivPathForTest } = await import("../src/process-group.js");
+    _setSetprivPathForTest(undefined);
+  });
+
+  it("wraps the command with `setpriv --pdeathsig TERM --` when setpriv is available on Linux", async () => {
+    if (process.platform !== "linux") return; // simulator only — Linux semantics
+    const { spawnInGroup, _setSetprivPathForTest } = await import("../src/process-group.js");
+    _setSetprivPathForTest("/usr/bin/setpriv");
+    spawnInGroup("gemini", ["--yolo"], { stdio: "ignore" });
+    expect(lastSpawnArgs).not.toBeNull();
+    expect(lastSpawnArgs!.command).toBe("/usr/bin/setpriv");
+    expect(lastSpawnArgs!.args).toEqual(["--pdeathsig", "TERM", "--", "gemini", "--yolo"]);
+    // Process-group leadership must still apply — the setpriv shim becomes the
+    // group leader and the real CLI inherits the group, so killGroup() works.
+    expect(lastSpawnArgs!.options.detached).toBe(true);
+    // Caller-supplied options are preserved.
+    expect(lastSpawnArgs!.options.stdio).toBe("ignore");
+  });
+
+  it("falls through (no wrap) when setpriv is not installed on Linux", async () => {
+    if (process.platform !== "linux") return;
+    const { spawnInGroup, _setSetprivPathForTest } = await import("../src/process-group.js");
+    _setSetprivPathForTest(null);
+    spawnInGroup("gemini", ["--yolo"], { stdio: "ignore" });
+    expect(lastSpawnArgs!.command).toBe("gemini");
+    expect(lastSpawnArgs!.args).toEqual(["--yolo"]);
+    expect(lastSpawnArgs!.options.detached).toBe(true);
+  });
+
+  it("falls through (no wrap) when GEMINI_DISABLE_PDEATHSIG=1 even if setpriv is available", async () => {
+    if (process.platform !== "linux") return;
+    process.env.GEMINI_DISABLE_PDEATHSIG = "1";
+    const { spawnInGroup, _setSetprivPathForTest } = await import("../src/process-group.js");
+    _setSetprivPathForTest("/usr/bin/setpriv");
+    spawnInGroup("gemini", ["--yolo"], { stdio: "ignore" });
+    expect(lastSpawnArgs!.command).toBe("gemini");
+    expect(lastSpawnArgs!.args).toEqual(["--yolo"]);
+  });
+
+  it("falls through (no wrap) when GEMINI_DISABLE_PDEATHSIG is set to any non-'1' value? (only '1' disables)", async () => {
+    // Documents the contract: only the literal string "1" disables. "true",
+    // "yes", or empty string DO NOT disable — matches the codebase convention
+    // for env-var booleans (see GEMINI_POOL_ENABLED, GEMINI_STRUCTURED_LOGS).
+    if (process.platform !== "linux") return;
+    process.env.GEMINI_DISABLE_PDEATHSIG = "true"; // not "1"
+    const { spawnInGroup, _setSetprivPathForTest } = await import("../src/process-group.js");
+    _setSetprivPathForTest("/usr/bin/setpriv");
+    spawnInGroup("gemini", ["--yolo"], { stdio: "ignore" });
+    // "true" is not "1" — wrap remains active
+    expect(lastSpawnArgs!.command).toBe("/usr/bin/setpriv");
+  });
+});
+
+describe("spawnInGroup setpriv wrap is Linux-only", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    vi.resetModules();
+  });
+
+  it("does NOT wrap on macOS even if a setpriv path is configured", async () => {
+    // setpriv (util-linux) does not exist on macOS; even hypothetically forcing
+    // a path must not cause us to invoke a non-existent shim.
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    vi.resetModules();
+    const { spawnInGroup, _setSetprivPathForTest } = await import("../src/process-group.js");
+    _setSetprivPathForTest("/usr/bin/setpriv"); // hypothetical; should be ignored
+    spawnInGroup("gemini", ["--yolo"], { stdio: "ignore" });
+    expect(lastSpawnArgs!.command).toBe("gemini");
+    expect(lastSpawnArgs!.args).toEqual(["--yolo"]);
+    expect(lastSpawnArgs!.options.detached).toBe(true); // POSIX still applies
+  });
+});
+


### PR DESCRIPTION
## Summary

Bundles two defense-in-depth sub-issues of epic #96 (orphan grandchild process leak). The primary fix shipped in PR #100 (`dd85fec`) handles graceful shutdown; #98 / PR #102 (`ccf2303`) eliminated the npm shim. Two failure modes still leak orphans:

1. **Ungraceful exit** (SIGKILL, OOM, hard crash) — JS shutdown handler never runs (#97).
2. **Pre-existing orphans** from older versions / future regressions don't self-clean (#99).

This PR layers two complementary mitigations:

- **#97** — `setpriv --pdeathsig TERM --` wrapper on Linux. Kernel delivers SIGTERM to children the moment the MCP parent dies, regardless of how it died. No userspace cleanup required. Util-linux ≥ 2.33 (every modern distro). Probe-once-at-startup; falls through cleanly when missing or via `GEMINI_DISABLE_PDEATHSIG=1`.
- **#99** — Startup orphan reaper. POSIX-only sweep at module load (Linux `/proc`, macOS `ps -A`); filters by **UID == process.getuid() AND PPID is a subreaper-set ancestor AND cmdline contains `--yolo --output-format stream-json`**. SIGTERM all matches → wait 2s → re-list and SIGKILL survivors that still match the signature (PID-reuse race protection). Telemetry per signal when `GEMINI_STRUCTURED_LOGS=1`. Disable via `GEMINI_ORPHAN_REAPER=0`.

The reaper's filter cannot false-positive on our own newborn warm-pool members (their PPID == our PID, never a root-owned ancestor), so the module-load fire-and-forget hook is safe to run concurrently with `WarmProcessPool` startup.

Fixes #97
Fixes #99

## Discovered during integration testing: subreaper environments

The first cut of #99 used a strict `ppid === 1` filter, matching the issue body's spec. End-to-end testing on this WSL2 environment surfaced that orphans don't always reparent to PID 1: since Linux 3.4, processes can register as "child subreapers" via `prctl(PR_SET_CHILD_SUBREAPER)`, and the kernel reparents orphans to the nearest subreaper ancestor instead of PID 1. WSL2's per-namespace `/init`, systemd-user, container runtimes, and modern shells all do this.

Commit `606ff3c` widens the filter: at module load we walk `/proc/self`'s parent chain and collect every root-owned (UID 0) ancestor PID. Plus PID 1 as a sentinel. Non-root ancestors (user shell, host process) are excluded — root-ownership is a practical proxy for "system-level subreaper" (any UID can call `PR_SET_CHILD_SUBREAPER`, but the subreapers we want to handle are root-owned in practice). Sibling MCP servers' attached pool members are spared because their PPID is the user-owned sibling MCP, not a root-owned ancestor.

## Commits

| SHA | Subject | Issue |
|---|---|---|
| `986816b` | `fix(process-group): wrap spawns with setpriv --pdeathsig TERM on Linux` | #97 |
| `542e0a7` | `feat(orphan-reaper): sweep PID-1-orphaned gemini workers at startup` | #99 |
| `606ff3c` | `fix(orphan-reaper): widen filter to root-owned subreaper ancestors` | #99 |
| `6110c67` | `fix: address PR review findings — orphan reaper hardening + doc accuracy` | review |

## AI Review Notes (5 Claude agents + Gemini batch)

Confirmed and fixed:

- **PID-reuse race in SIGKILL escalation** (Claude code-reviewer + Gemini). Between SIGTERM and the 2 s SIGKILL window, the kernel could recycle a freed PID for an unrelated same-user process. Fixed by re-listing the process table before SIGKILL and verifying the PID still matches the original UID + cmdline signature. Conservative fallback: if the re-list call itself fails, skip SIGKILL entirely (next startup sweep handles stragglers).
- **`setpriv --version` probe didn't validate the actual flag** (Gemini). On Ubuntu 18.04 / CentOS 7 (util-linux 2.31) the binary exists but `--pdeathsig` doesn't, so `--version` would falsely succeed and every subsequent spawn would fail with "unrecognized option". Probe now runs `setpriv --pdeathsig TERM -- true`. Non-ENOENT failures now warn on stderr so a silently-disabled PDEATHSIG safety net is debuggable (suppressed when `GEMINI_DISABLE_PDEATHSIG=1`).
- **Adapter failure was a silent no-op** (Claude silent-failure-hunter). `reapOrphans` now logs an `orphan_reaper_list_failed` structured event AND writes a stderr line when the process-list call rejects.
- **`failed > 0` was discarded by the caller** (Claude silent-failure-hunter). `gemini-runner.ts` now writes a stderr line when reapOrphans returns a non-zero `failed` count.
- **`GEMINI_ORPHAN_REAPER=0` kill-switch was untested** (Claude pr-test-analyzer). Added 3 new tests in `tests/gemini-runner-binary-discovery.test.ts` covering the unset / `=0` / `=non-'0'` cases.
- **`_subreaperCache` cross-test contamination** (Claude pr-test-analyzer). Added `_resetSubreaperCacheForTest()` to `afterEach` so the order of tests that omit `subreaperPids` no longer matters.
- **Doc/comment drift** (Claude comment-analyzer). Multiple sites still said "PPID==1 filter" / "PID-1-orphaned" after `606ff3c` widened to subreaper-set membership. Updated in `CLAUDE.md`, `orphan-reaper.ts` module header, and `gemini-runner.ts` call-site comment. Also corrected the kernel version for `PR_SET_CHILD_SUBREAPER` (Linux 3.4, not 2.6.36) and replaced a factually wrong "by definition" rationale for excluding non-root ancestors with the real sibling-MCP-safety reasoning.

Considered and skipped (verified false positive or YAGNI):

- Self-kill exclusion (Gemini): impossible — MCP cmdline is `node dist/index.js`, never matches the `--yolo --output-format stream-json` signature.
- Loose-signature-matching refactor (Gemini): false-positive surface is essentially nil; would require args-array refactor for marginal gain.
- Type-design polishes (branded `Pid`, `StreamEvent` discriminated union, `NonEmptySignature` tuple, etc.): YAGNI per CLAUDE.md.
- `clockTicks=100` stronger caveat, vacuous Linux-only test passes on non-Linux CI, `/proc/uptime` null-path test, macOS `etime` `HH:MM:SS` format test, "child" vs "setpriv shim" wording: low marginal value.

## Test plan

### Automated (CI / `npm test`)

- [x] `npm run build` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — **643 / 643 passing** (619 pre-existing + 24 new across orphan-reaper / process-group / gemini-runner-binary-discovery)

### Live-system smoke (#99)

- [x] Linux `/proc` parser against real `/proc`: lists 331+ processes, finds self correctly, identifies live `gemini --yolo` candidates.
- [x] `reapOrphans` against live system with mock `kill`: zero invocations against the 24+ live attached pool members (strict subreaper-set filter).

### #97 PDEATHSIG end-to-end on Linux/WSL2

- [x] Spawn isolated test MCP (`GEMINI_POOL_SIZE=1`). Verify warm-pool child exists.
- [x] `kill -9` the test MCP parent. Sleep 1.5 s. **Child confirmed dead** — kernel delivered SIGTERM via PR_SET_PDEATHSIG.
- [x] Repeat with `GEMINI_DISABLE_PDEATHSIG=1`: child **survives** (escape-hatch verified). The orphaned child is reparented to the WSL2 user-namespace `/init` (PID 748339, root-owned), confirming the subreaper environment.
- [x] **Review-fix verification:** new probe `setpriv --pdeathsig TERM -- true` succeeds on this WSL2 host (util-linux 2.39.3); behavior identical to the prior `--version` probe on supported distros.

### #99 reaper end-to-end on Linux/WSL2

- [x] Pre-fix (commits `542e0a7`): create real orphan (PPID 748339), run `reapOrphans` dry-run → `{reaped: 0}` ❌ (bug surfaced).
- [x] Post-fix (commit `606ff3c`): same orphan, same reaper → `{reaped: 1}` ✅ with telemetry showing SIGTERM → re-list → SIGKILL escalation.
- [x] Live attached pool members not affected (verified by mock-kill dry-run against full live process table).

### #99 reaper unit coverage (post-review-fix)

- [x] WSL2-style orphan with explicit `subreaperPids: {1, 748339}` is reaped.
- [x] Sibling MCP server's attached pool member (PPID = user-owned process) is **not** reaped.
- [x] Default subreaper set always contains PID 1 (regression guard for non-WSL2 systems).
- [x] **PID-reuse race protection:** re-list returns same PID with different cmdline → SIGKILL is **NOT** sent (review-fix coverage).
- [x] **Re-list failure fallback:** if the re-list call itself rejects, SIGKILL is **NOT** escalated (review-fix coverage).
- [x] **Adapter failure visibility:** `listProcesses()` rejecting writes stderr + `orphan_reaper_list_failed` structured event (review-fix coverage).
- [x] **`GEMINI_ORPHAN_REAPER=0` kill-switch:** unset / `=0` / `=non-'0'` cases all behave correctly (review-fix coverage).

### No-regression on the 6 required CLAUDE.md scenarios

- [x] `ask-gemini` basic prompt with `wait: true` → response returned inline.
- [x] `gemini-reply` continuing the session → prior context preserved.
- [x] Async `ask-gemini` (`wait: false`) + `gemini-poll` → poll returns `done` with response.
- [x] `gemini-cancel` of in-flight job → returns `cancelled: true`; poll shows `cancelled` status.
- [x] `@src/process-group.ts` reference expansion → Gemini correctly identified `spawnInGroup`.
- [x] Two concurrent `ask-gemini` calls → both completed (semaphore + warm pool healthy).

> Note: review-fix commit `6110c67` does not touch user-facing tool surfaces. Unit tests cover all new logic paths; the 6 scenarios above were validated end-to-end during the original commits and the affected code paths (cold spawn / session / poll / cancel / @file expansion / concurrency) are unchanged in this commit.

## Files

| File | Issue | Change |
|---|---|---|
| `src/process-group.ts` | #97 | `detectSetpriv()` sync probe (now exercises `--pdeathsig TERM -- true`) + cache; `spawnInGroup()` wraps with setpriv on Linux when available |
| `src/orphan-reaper.ts` | #99 | New module — `reapOrphans()` business logic (re-list before SIGKILL for race protection) + Linux `/proc` parser + macOS `ps` parser + subreaper-ancestor walk |
| `src/gemini-runner.ts` | #99 | Fire-and-forget `reapOrphans()` at module load before `WarmProcessPool` constructor; surfaces `failed > 0` to stderr |
| `tests/process-group.test.ts` | #97 | 5 cases for setpriv wrapping |
| `tests/orphan-reaper.test.ts` | #99 | 22 cases — business logic, parsers, subreaper handling, PID-reuse race protection, adapter-failure logging, `_subreaperCache` test isolation |
| `tests/gemini-runner-binary-discovery.test.ts` | #97/#99 | `GEMINI_DISABLE_PDEATHSIG=1` isolation in `beforeEach`; 3 cases for `GEMINI_ORPHAN_REAPER` kill-switch |
| `CLAUDE.md` | both | Two new env-var rows |

## Out of scope

- macOS PDEATHSIG equivalent (no kernel mechanism — separate sub-issue if/when needed)
- Windows Job Objects for ungraceful-exit cleanup
- macOS subreaper-ancestor walk (the WSL2 fix's `findLinuxSubreaperAncestors` is Linux-only; macOS reaper still seeds with `{1}` only). Could be added if macOS users observe orphans reparented elsewhere.
- Closing epic #96 (will close after this PR merges)
- Native `prctl` addon path (rejected in favor of `setpriv` shim)