### PR TITLE
feat: pool-drift verifier + upstream-watch CI repair

### DIFF
--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -13,7 +13,7 @@ jobs:
   check-upstream:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get latest upstream version
         id: upstream
@@ -45,9 +45,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LATEST: ${{ steps.compare.outputs.latest }}
         run: |
+          # `gh --jq` accepts only one expression argument; --arg is a jq-binary
+          # flag, not a gh flag. Pipe the JSON to standalone jq instead so we
+          # can use --arg safely without shell-quoting the version inline.
           COUNT=$(gh issue list --label upstream-update --state open --json title \
-            --jq --arg latest "$LATEST" \
-            '[.[] | select(.title == "upstream: gemini-cli \($latest) released" or (.title | startswith("upstream: gemini-cli \($latest) ")))] | length')
+            | jq --arg latest "$LATEST" \
+                '[.[] | select(.title == "upstream: gemini-cli \($latest) released" or (.title | startswith("upstream: gemini-cli \($latest) ")))] | length')
           echo "exists=$([ "$COUNT" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: Create tracking issue

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Get latest upstream version
         id: upstream
         run: |
+          set -eo pipefail
+          # 2>/dev/null suppresses npm's verbose error block on network failure;
+          # the empty-string guard below is the user-visible failure path.
           LATEST=$(npm view @google/gemini-cli version 2>/dev/null || echo "")
           if [ -z "$LATEST" ]; then
             echo "::error::Failed to fetch upstream version"
@@ -28,7 +31,10 @@ jobs:
       - name: Compare with tracked version
         id: compare
         run: |
-          TRACKED=$(cat .github/upstream-version.txt | tr -d '[:space:]')
+          set -eo pipefail
+          # tr < file (not cat | tr) so a missing version file fails loudly
+          # instead of silently producing TRACKED="" and a false-positive drift.
+          TRACKED=$(tr -d '[:space:]' < .github/upstream-version.txt)
           LATEST="${{ steps.upstream.outputs.version }}"
           echo "tracked=$TRACKED" >> "$GITHUB_OUTPUT"
           echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
@@ -45,9 +51,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LATEST: ${{ steps.compare.outputs.latest }}
         run: |
+          set -eo pipefail
           # `gh --jq` accepts only one expression argument; --arg is a jq-binary
           # flag, not a gh flag. Pipe the JSON to standalone jq instead so we
           # can use --arg safely without shell-quoting the version inline.
+          # pipefail (above) ensures a gh failure (auth/rate limit) is not
+          # masked by jq's exit code.
           COUNT=$(gh issue list --label upstream-update --state open --json title \
             | jq --arg latest "$LATEST" \
                 '[.[] | select(.title == "upstream: gemini-cli \($latest) released" or (.title | startswith("upstream: gemini-cli \($latest) ")))] | length')

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint src",
     "test": "vitest run",
     "test:smoke": "node scripts/mcp-smoke.mjs",
+    "verify:pool": "node scripts/verify-pool.mjs",
     "test:watch": "vitest",
     "prepare": "npm run build"
   },

--- a/scripts/verify-pool-logic.mjs
+++ b/scripts/verify-pool-logic.mjs
@@ -1,0 +1,113 @@
+/**
+ * verify-pool-logic.mjs — pure logic for the warm-pool verification script.
+ *
+ * Split from verify-pool.mjs so decideVerdict can be unit-tested without
+ * spawning real subprocesses or reading env vars.
+ */
+
+import { spawnSync } from "node:child_process";
+
+/**
+ * The exact cmdline fingerprint of a warm-pool worker. Must match the args
+ * passed at src/gemini-runner.ts:218 (warm pool) and the orphan-reaper
+ * signature at src/gemini-runner.ts:183 (which is consumed by the matching
+ * logic in src/orphan-reaper.ts:86 — `matchesSignature` does an `includes()`
+ * against the joined-by-space form, which is why we use the same here).
+ *
+ * If you change the warm-pool args, update all three sites.
+ */
+export const PGREP_PATTERN = "gemini --yolo --output-format stream-json";
+
+/**
+ * Count running workers via `pgrep -af`. Uses spawnSync with an argv array
+ * (no shell) so the wrapping shell's cmdline doesn't show up in the matches —
+ * that off-by-one trap was caught during PR review of the original execSync
+ * implementation.
+ *
+ * Distinguishes:
+ *   - exit 0  → matches found, count = lines of output
+ *   - exit 1  → no matches (pgrep convention), return 0
+ *   - ENOENT  → pgrep not on PATH; throws PgrepUnavailableError
+ *   - other   → real failure (signal, syntax error); rethrows the spawnSync error
+ */
+export function countProcesses() {
+  const result = spawnSync("pgrep", ["-af", PGREP_PATTERN], {
+    encoding: "utf8",
+  });
+
+  if (result.error?.code === "ENOENT") {
+    const e = new Error(
+      "pgrep not found on PATH. Install procps (Linux) or use a system " +
+        "where pgrep is built-in (macOS, BSD)."
+    );
+    e.code = "PGREP_NOT_FOUND";
+    throw e;
+  }
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status === 1) {
+    return 0;
+  }
+  if (result.status !== 0) {
+    const e = new Error(
+      `pgrep exited with status ${result.status} ` +
+        `(signal=${result.signal ?? "none"}); stderr: ${result.stderr?.trim() ?? ""}`
+    );
+    e.code = "PGREP_FAILED";
+    throw e;
+  }
+
+  return result.stdout.trim().split("\n").filter(Boolean).length;
+}
+
+/**
+ * Decide the verdict given a stabilized count and the expected pool size.
+ *
+ * Cases (all hard-fail except case 1):
+ *   1. count === expected (and both > 0)   → exit 0, gate holding
+ *   2. expected === 0                       → exit 1, pool is disabled — script not meaningful
+ *   3. count === expected * 2 (expected > 0) → exit 1, gate broken (relaunch doubling)
+ *   4. count === 0 (expected > 0)           → exit 1, no workers — server down or ENV problem
+ *   5. anything else                        → exit 1, unhealthy or noise from another session
+ *
+ * The expected===0 case must be checked before the count===expected case,
+ * otherwise count===expected===0 falsely reports "gate holding".
+ */
+export function decideVerdict(count, expected) {
+  if (expected <= 0) {
+    return {
+      ok: false,
+      message:
+        `pool size is ${expected}; verify:pool is meaningless when the warm pool is disabled. ` +
+        "Set GEMINI_POOL_SIZE (or GEMINI_MAX_CONCURRENT) to a positive integer, or run with the warm pool enabled.",
+    };
+  }
+  if (count === expected) {
+    return { ok: true, message: "gate holding (1 process per slot)" };
+  }
+  if (count === expected * 2) {
+    return {
+      ok: false,
+      message:
+        "gate BROKEN — relaunch is doubling processes. " +
+        "GEMINI_CLI_NO_RELAUNCH no longer suppresses self-relaunch in upstream. " +
+        "See src/cli-capabilities.ts (GEMINI_CHILD_ENV_OVERRIDES).",
+    };
+  }
+  if (count === 0) {
+    return {
+      ok: false,
+      message:
+        "no workers detected. Is the MCP server running? " +
+        `Check \`pgrep -af '${PGREP_PATTERN}'\` directly, or restart Claude Code. ` +
+        "If GEMINI_POOL_ENABLED=0, the pool is intentionally disabled.",
+    };
+  }
+  return {
+    ok: false,
+    message:
+      `unexpected count=${count}, expected ${expected} or ${expected * 2}. ` +
+      "Pool may be partially failed, or another `gemini --yolo` worker is running in a separate session.",
+  };
+}

--- a/scripts/verify-pool.mjs
+++ b/scripts/verify-pool.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * verify-pool.mjs — manual integration check for issue #98 contract.
+ *
+ * Counts running `gemini --yolo --output-format stream-json` worker processes
+ * and compares against the expected warm-pool size.
+ *
+ * Why: upstream @google/gemini-cli runs `relaunchAppInChildProcess`, which
+ * re-execs itself with --max-old-space-size, producing 2 Node processes per
+ * warm-pool slot. We suppress this by injecting GEMINI_CLI_NO_RELAUNCH=true
+ * (see src/cli-capabilities.ts: GEMINI_CHILD_ENV_OVERRIDES). The unit tests
+ * mock spawn, so they cannot observe runtime fork behavior — this script is
+ * the only signal that the env-var gate still holds in upstream.
+ *
+ * Verdicts:
+ *   count == expected      → ✅ gate holding (1 process per slot)
+ *   count == expected * 2  → ❌ gate broken (relaunch is doubling processes)
+ *   count == 0             → ❓ MCP server not running, or pool disabled
+ *   other                  → ⚠️ pool mid-spawn or unhealthy (see verdict logic)
+ *
+ * Usage:
+ *   npm run verify:pool                    # poll until stable, then verdict
+ *   GEMINI_POOL_SIZE=4 npm run verify:pool # match a non-default pool size
+ *
+ * Caveat:
+ *   pgrep counts ALL `gemini --yolo --output-format stream-json` processes
+ *   owned by the user, not just this server's pool. If multiple Claude Code
+ *   sessions are running concurrently, expect counts to exceed GEMINI_POOL_SIZE.
+ *   For an authoritative single-session check: stop other Claude Code instances
+ *   first, or `pgrep -af` and inspect the parent PIDs manually.
+ *
+ * Tunables (all optional):
+ *   GEMINI_POOL_SIZE        — expected count (default: GEMINI_MAX_CONCURRENT or 2)
+ *   GEMINI_MAX_CONCURRENT   — fallback expected count
+ *   VERIFY_POOL_TIMEOUT_MS  — give up polling after this long (default 30000)
+ *   VERIFY_POOL_SETTLE_MS   — count must be unchanged this long (default 3000)
+ */
+
+import { execSync } from "node:child_process";
+import process from "node:process";
+
+const expected = Number(
+  process.env.GEMINI_POOL_SIZE ??
+    process.env.GEMINI_MAX_CONCURRENT ??
+    2
+);
+const timeoutMs = Number(process.env.VERIFY_POOL_TIMEOUT_MS ?? 30_000);
+const settleMs = Number(process.env.VERIFY_POOL_SETTLE_MS ?? 3000);
+
+// Match the full worker invocation, not just `gemini --yolo`, to avoid
+// false positives from interactive Gemini sessions in other terminals.
+// Mirrors the orphan-reaper fingerprint in src/gemini-runner.ts (issue #99).
+const PGREP_PATTERN = "gemini --yolo --output-format stream-json";
+
+function countProcesses() {
+  try {
+    const out = execSync(`pgrep -af ${JSON.stringify(PGREP_PATTERN)}`, {
+      encoding: "utf8",
+    });
+    return out.trim().split("\n").filter(Boolean).length;
+  } catch (e) {
+    // pgrep exits 1 when no matches; that's count=0, not an error.
+    if (e.status === 1) return 0;
+    throw e;
+  }
+}
+
+async function pollUntilStable() {
+  const start = Date.now();
+  let lastCount = -1;
+  let stableSince = 0;
+
+  while (Date.now() - start < timeoutMs) {
+    const c = countProcesses();
+    const now = Date.now();
+
+    if (c !== lastCount) {
+      lastCount = c;
+      stableSince = now;
+      process.stderr.write(`[verify-pool] count=${c} (changing)\n`);
+    } else if (now - stableSince >= settleMs) {
+      return c;
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  return lastCount;
+}
+
+// ── verdict ──────────────────────────────────────────────────────────────────
+// Hard-fail policy: exit 1 unless count exactly matches expected.
+
+function decideVerdict(count, expected) {
+  if (count === expected) {
+    return { ok: true, message: "✅ gate holding (1 process per slot)" };
+  }
+  if (count === expected * 2) {
+    return {
+      ok: false,
+      message:
+        "❌ gate BROKEN — relaunch is doubling processes. " +
+        "GEMINI_CLI_NO_RELAUNCH no longer suppresses self-relaunch in upstream. " +
+        "See src/cli-capabilities.ts (GEMINI_CHILD_ENV_OVERRIDES) and CLAUDE.md issue #98.",
+    };
+  }
+  if (count === 0) {
+    return {
+      ok: false,
+      message:
+        "❓ no workers detected. Is the MCP server running? " +
+        "Check `pgrep -af 'gemini --yolo'` directly, or restart Claude Code. " +
+        "If GEMINI_POOL_ENABLED=0, the pool is intentionally disabled.",
+    };
+  }
+  return {
+    ok: false,
+    message:
+      `⚠️ unexpected count=${count}, expected ${expected} or ${expected * 2}. ` +
+      "Pool may be partially failed, or another `gemini --yolo` is running in a separate session.",
+  };
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+const count = await pollUntilStable();
+const verdict = decideVerdict(count, expected);
+
+console.log(`gemini --yolo workers: ${count}`);
+console.log(`expected:              ${expected}`);
+console.log(verdict.message);
+process.exit(verdict.ok ? 0 : 1);

--- a/scripts/verify-pool.mjs
+++ b/scripts/verify-pool.mjs
@@ -12,11 +12,15 @@
  * mock spawn, so they cannot observe runtime fork behavior — this script is
  * the only signal that the env-var gate still holds in upstream.
  *
- * Verdicts:
- *   count == expected      → ✅ gate holding (1 process per slot)
- *   count == expected * 2  → ❌ gate broken (relaunch is doubling processes)
- *   count == 0             → ❓ MCP server not running, or pool disabled
- *   other                  → ⚠️ pool mid-spawn or unhealthy (see verdict logic)
+ * Verdicts and exit codes:
+ *   count == expected      → exit 0 (gate holding, 1 process per slot)
+ *   count == expected * 2  → exit 1 (gate broken, relaunch doubling)
+ *   count == 0             → exit 1 (server down or pool disabled)
+ *   expected <= 0          → exit 1 (verify:pool is meaningless when pool is disabled)
+ *   anything else          → exit 1 (mid-spawn, partial failure, or noise)
+ *   fatal (pgrep ENOENT,
+ *      pollUntilStable
+ *      throw, etc.)        → exit 2
  *
  * Usage:
  *   npm run verify:pool                    # poll until stable, then verdict
@@ -27,17 +31,22 @@
  *   owned by the user, not just this server's pool. If multiple Claude Code
  *   sessions are running concurrently, expect counts to exceed GEMINI_POOL_SIZE.
  *   For an authoritative single-session check: stop other Claude Code instances
- *   first, or `pgrep -af` and inspect the parent PIDs manually.
+ *   first, or run the same pgrep manually and inspect the parent PIDs.
  *
  * Tunables (all optional):
  *   GEMINI_POOL_SIZE        — expected count (default: GEMINI_MAX_CONCURRENT or 2)
  *   GEMINI_MAX_CONCURRENT   — fallback expected count
- *   VERIFY_POOL_TIMEOUT_MS  — give up polling after this long (default 30000)
- *   VERIFY_POOL_SETTLE_MS   — count must be unchanged this long (default 3000)
+ *   VERIFY_POOL_TIMEOUT_MS  — give up polling after this long (default 30000).
+ *                             Setting this to 0 disables polling — the script
+ *                             samples once and verdicts immediately.
+ *   VERIFY_POOL_SETTLE_MS   — count must be unchanged this long before the
+ *                             verdict fires (default 3000). Effective wall-time
+ *                             may be up to settleMs + 1s due to the 1-second
+ *                             polling interval.
  */
 
-import { execSync } from "node:child_process";
 import process from "node:process";
+import { countProcesses, decideVerdict } from "./verify-pool-logic.mjs";
 
 const expected = Number(
   process.env.GEMINI_POOL_SIZE ??
@@ -47,28 +56,19 @@ const expected = Number(
 const timeoutMs = Number(process.env.VERIFY_POOL_TIMEOUT_MS ?? 30_000);
 const settleMs = Number(process.env.VERIFY_POOL_SETTLE_MS ?? 3000);
 
-// Match the full worker invocation, not just `gemini --yolo`, to avoid
-// false positives from interactive Gemini sessions in other terminals.
-// Mirrors the orphan-reaper fingerprint in src/gemini-runner.ts (issue #99).
-const PGREP_PATTERN = "gemini --yolo --output-format stream-json";
-
-function countProcesses() {
-  try {
-    const out = execSync(`pgrep -af ${JSON.stringify(PGREP_PATTERN)}`, {
-      encoding: "utf8",
-    });
-    return out.trim().split("\n").filter(Boolean).length;
-  } catch (e) {
-    // pgrep exits 1 when no matches; that's count=0, not an error.
-    if (e.status === 1) return 0;
-    throw e;
-  }
+if (!Number.isFinite(expected) || !Number.isFinite(timeoutMs) || !Number.isFinite(settleMs)) {
+  process.stderr.write(
+    `[verify-pool] FATAL: non-numeric env var. ` +
+      `expected=${expected}, timeoutMs=${timeoutMs}, settleMs=${settleMs}\n`
+  );
+  process.exit(2);
 }
 
 async function pollUntilStable() {
   const start = Date.now();
   let lastCount = -1;
   let stableSince = 0;
+  let lastLogAt = 0;
 
   while (Date.now() - start < timeoutMs) {
     const c = countProcesses();
@@ -77,54 +77,43 @@ async function pollUntilStable() {
     if (c !== lastCount) {
       lastCount = c;
       stableSince = now;
+      lastLogAt = now;
       process.stderr.write(`[verify-pool] count=${c} (changing)\n`);
     } else if (now - stableSince >= settleMs) {
-      return c;
+      return { count: c, settled: true };
+    } else if (now - lastLogAt >= 5000) {
+      lastLogAt = now;
+      process.stderr.write(`[verify-pool] count=${c} (settling, ${Math.floor((settleMs - (now - stableSince)) / 1000)}s remaining)\n`);
     }
     await new Promise((r) => setTimeout(r, 1000));
   }
-  return lastCount;
+  return { count: lastCount, settled: false };
 }
 
-// ── verdict ──────────────────────────────────────────────────────────────────
-// Hard-fail policy: exit 1 unless count exactly matches expected.
-
-function decideVerdict(count, expected) {
-  if (count === expected) {
-    return { ok: true, message: "✅ gate holding (1 process per slot)" };
+let pollResult;
+try {
+  pollResult = timeoutMs <= 0
+    ? { count: countProcesses(), settled: true }
+    : await pollUntilStable();
+} catch (e) {
+  if (e.code === "PGREP_NOT_FOUND") {
+    process.stderr.write(`[verify-pool] FATAL: ${e.message}\n`);
+    process.exit(2);
   }
-  if (count === expected * 2) {
-    return {
-      ok: false,
-      message:
-        "❌ gate BROKEN — relaunch is doubling processes. " +
-        "GEMINI_CLI_NO_RELAUNCH no longer suppresses self-relaunch in upstream. " +
-        "See src/cli-capabilities.ts (GEMINI_CHILD_ENV_OVERRIDES) and CLAUDE.md issue #98.",
-    };
-  }
-  if (count === 0) {
-    return {
-      ok: false,
-      message:
-        "❓ no workers detected. Is the MCP server running? " +
-        "Check `pgrep -af 'gemini --yolo'` directly, or restart Claude Code. " +
-        "If GEMINI_POOL_ENABLED=0, the pool is intentionally disabled.",
-    };
-  }
-  return {
-    ok: false,
-    message:
-      `⚠️ unexpected count=${count}, expected ${expected} or ${expected * 2}. ` +
-      "Pool may be partially failed, or another `gemini --yolo` is running in a separate session.",
-  };
+  process.stderr.write(`[verify-pool] FATAL: process counting failed: ${e.message}\n`);
+  process.exit(2);
 }
 
-// ── main ─────────────────────────────────────────────────────────────────────
+if (!pollResult.settled) {
+  process.stderr.write(
+    `[verify-pool] WARNING: timed out after ${timeoutMs}ms without count stabilizing. ` +
+      `Last seen count=${pollResult.count}. Verdict reflects last sample.\n`
+  );
+}
 
-const count = await pollUntilStable();
-const verdict = decideVerdict(count, expected);
+const verdict = decideVerdict(pollResult.count, expected);
 
-console.log(`gemini --yolo workers: ${count}`);
+console.log(`gemini --yolo workers: ${pollResult.count}`);
 console.log(`expected:              ${expected}`);
 console.log(verdict.message);
 process.exit(verdict.ok ? 0 : 1);

--- a/src/gemini-runner.ts
+++ b/src/gemini-runner.ts
@@ -213,6 +213,9 @@ if (POOL_ENABLED && !SETUP_MODE) {
       `[gemini-cli-mcp] first run detected — increased pool startup to ${effectiveStartupMs}ms\n`
     );
   }
+  // The args here MUST match the orphan-reaper signature on line 183 and
+  // PGREP_PATTERN in scripts/verify-pool-logic.mjs. If you change them, update
+  // all three sites — there's no automated coupling.
   warmPool = new WarmProcessPool(
     Number.isFinite(POOL_SIZE) && POOL_SIZE >= 1 ? POOL_SIZE : MAX_CONCURRENT,
     ["--yolo", "--output-format", "stream-json"],

--- a/tests/verify-pool-logic.test.ts
+++ b/tests/verify-pool-logic.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+// @ts-expect-error — JS module without type declarations; behavior is exercised here.
+import { decideVerdict, PGREP_PATTERN } from "../scripts/verify-pool-logic.mjs";
+
+describe("decideVerdict", () => {
+  it("count === expected → ok=true (gate holding)", () => {
+    const v = decideVerdict(2, 2);
+    expect(v.ok).toBe(true);
+    expect(v.message).toContain("gate holding");
+  });
+
+  it("count === expected * 2 → ok=false (gate broken)", () => {
+    const v = decideVerdict(4, 2);
+    expect(v.ok).toBe(false);
+    expect(v.message).toContain("gate BROKEN");
+    expect(v.message).toContain("relaunch is doubling");
+  });
+
+  it("count === 0 (expected > 0) → ok=false (no workers)", () => {
+    const v = decideVerdict(0, 2);
+    expect(v.ok).toBe(false);
+    expect(v.message).toContain("no workers detected");
+  });
+
+  it("ambiguous count → ok=false", () => {
+    const v = decideVerdict(3, 2);
+    expect(v.ok).toBe(false);
+    expect(v.message).toContain("unexpected count=3");
+    expect(v.message).toContain("expected 2 or 4");
+  });
+
+  it("expected === 0 with count === 0 → ok=false (does NOT report gate holding)", () => {
+    // This is the case the original implementation got wrong: a disabled pool
+    // reported a green "gate holding" result because count===expected===0
+    // matched the first branch. The fix checks expected<=0 first.
+    const v = decideVerdict(0, 0);
+    expect(v.ok).toBe(false);
+    expect(v.message).toContain("disabled");
+    expect(v.message).not.toContain("gate holding");
+  });
+
+  it("expected === 0 with count > 0 → ok=false (still surfaces the disabled pool)", () => {
+    const v = decideVerdict(5, 0);
+    expect(v.ok).toBe(false);
+    expect(v.message).toContain("disabled");
+  });
+
+  it("negative expected is treated as disabled", () => {
+    // Defensive — Number(undefined ?? -1) is unlikely but the env-parsing
+    // path could in principle yield a negative if a user types one.
+    const v = decideVerdict(0, -1);
+    expect(v.ok).toBe(false);
+    expect(v.message).toContain("disabled");
+  });
+
+  it("error messages reference the full pgrep fingerprint, not the truncated form", () => {
+    // Regression: the original count===0 message said `pgrep -af 'gemini --yolo'`
+    // (would match interactive sessions), contradicting the rationale for the
+    // full pattern in PGREP_PATTERN.
+    const v = decideVerdict(0, 2);
+    expect(v.message).toContain(PGREP_PATTERN);
+    expect(v.message).not.toContain("pgrep -af 'gemini --yolo'");
+  });
+});
+
+describe("PGREP_PATTERN", () => {
+  it("matches the warm-pool worker fingerprint exactly", () => {
+    // If the warm-pool args at src/gemini-runner.ts:218 change, this test
+    // and the PGREP_PATTERN constant must be updated together.
+    expect(PGREP_PATTERN).toBe("gemini --yolo --output-format stream-json");
+  });
+});


### PR DESCRIPTION
## Summary

Two related changes that close the loop on upstream-version drift detection, plus correctness fixes from a multi-agent PR review.

1. **`npm run verify:pool`** — manual integration check for the issue #98 contract. Counts running `gemini --yolo --output-format stream-json` workers and verdicts against `GEMINI_POOL_SIZE`. Hard-fail policy: exit 0 only when count exactly matches expected. Polls until stable for 3s. Split into `scripts/verify-pool-logic.mjs` (testable pure functions) + `scripts/verify-pool.mjs` (CLI entry).

2. **`upstream-watch.yml` repair** (closes #104) — `gh --jq` accepts exactly one expression argument; `--arg` is a `jq` binary flag. Fix pipes JSON to standalone `jq`. Bumps `actions/checkout@v4 → v6`. Adds `set -eo pipefail` to all steps (without it, a `gh` auth/rate-limit failure silently caused duplicate-issue creation).

3. **Review fixes** — see Test Plan §"Review fixes verification" below.

## Test plan

### Impact coverage audit
- [x] **All files in the diff have been reviewed for points of impact** — `scripts/verify-pool.mjs` (rewritten as CLI entry), `scripts/verify-pool-logic.mjs` (new logic module), `tests/verify-pool-logic.test.ts` (new test file), `package.json` (one new script), `src/gemini-runner.ts` (coupling comment), `.github/workflows/upstream-watch.yml` (dedup + pipefail + checkout)
- [x] **Every identified impact point has a corresponding test scenario below**
- [x] Uncovered areas: _None_

### Documentation
- [x] **README / user-facing docs** — _Not affected: verify:pool is a maintainer/debugging tool, not part of the user API._
- [x] **API docs** — _Not affected: no API surface change._
- [x] **Inline code comments** — _Updated: full file headers in both verify-pool*.mjs explaining purpose, exit codes, tunables, multi-session caveat. Coupling note added at gemini-runner.ts:218._
- [x] **CHANGELOG / migration guide** — _Not affected: release-please autogenerates from conventional commits; the `feat:` and `fix:` subject lines drive the next entry._
- [x] **LLM / AI docs (CLAUDE.md)** — _Not affected: CLAUDE.md already documents the issue #98 contract and the manual `pgrep` step; verify:pool is a scriptable wrapper._
- [x] **Architecture Decision Records** — _Not affected: no architecture change._
- [x] **Runbooks / ops docs** — _Not affected: no ops surface._
- [x] **Contributing / dev setup** — _Not affected: existing contributors use `pgrep` directly._
- [x] **Security docs** — _Not affected: no auth/permission change._
- [x] **Environment / infra docs** (.env.example) — _Not affected: tunables are documented in the script header, consistent with other GEMINI_* env var docs in CLAUDE.md._
- [x] **Component / design system docs** — _Not affected: no UI._
- [x] **Error catalog / troubleshooting** — _Not affected: verdict messages are self-explanatory._

### Functional scenarios

#### Original PR scope

- [x] **Scenario: verify:pool — runs against current host without crashing**
  **Method:** CLI
  **Steps:**
  1. Run `npm run verify:pool`
  - [x] **Expected:** Exit code 1; output reports the worker count and a verdict message. ✅ Pass.

- [x] **Scenario: verify:pool — exit code semantics**
  **Method:** CLI (vitest unit tests cover decideVerdict)
  **Steps:**
  1. Run `npm test -- verify-pool-logic`
  - [x] **Expected:** All 5 verdict branches return the right `ok` flag. ✅ Pass — 9/9 tests in tests/verify-pool-logic.test.ts pass.

- [x] **Scenario: upstream-watch.yml — original `gh --jq --arg` reproduces failure**
  **Method:** CLI
  **Steps:**
  1. Run the original broken command locally with the broken `--jq --arg` form
  - [x] **Expected:** Exits non-zero with `unknown arguments [\"latest\" \"0.41.2\" ...]`. ✅ Pass — reproduced exactly.

- [x] **Scenario: upstream-watch.yml — fixed pipe form returns clean count**
  **Method:** CLI
  **Steps:**
  1. Run `gh issue list ... | jq --arg latest "0.41.2" '...'`
  - [x] **Expected:** Exits 0; returns 0 (no existing tracking issue for 0.41.2). ✅ Pass.

- [x] ⚠️ **Scenario: upstream-watch.yml — workflow runs end-to-end on GitHub** (user-approved-incomplete)
  **Method:** CLI (`gh workflow run upstream-watch.yml`) — _Live workflow trigger; only authoritative signal that the YAML is valid in CI context_
  **Steps:**
  1. After merge, manually dispatch the workflow via `gh workflow run upstream-watch.yml`
  2. Watch the run with `gh run watch`
  - [x] ⚠️ **Expected:** All steps exit 0. Since `.github/upstream-version.txt` (0.41.2) matches `npm view @google/gemini-cli version` (0.41.2), dedup step does not run. _Deferred to post-merge — workflow only runs on merged main or via dispatch. Risk accepted by reviewer (squash-merge option chosen with this scenario explicitly flagged as incomplete)._

#### Review fixes verification (added in Phase 3)

- [x] **Scenario: pgrep self-match bug fixed via spawnSync**
  **Method:** CLI
  **Steps:**
  1. Run `npm run verify:pool` and capture the count
  2. From a separate shell, run `pgrep -af "gemini --yolo --output-format stream-json" | wc -l`
  - [x] **Expected:** The two counts match exactly (no off-by-one from a wrapping shell). ✅ Pass — both reported 27 (was 28 vs 27 before the fix).

- [x] **Scenario: decideVerdict(0, 0) returns ok=false (was lying about gate holding)**
  **Method:** CLI
  **Steps:**
  1. Run `GEMINI_POOL_SIZE=0 npm run verify:pool`
  - [x] **Expected:** Exit 1; message says "pool size is 0; verify:pool is meaningless when the warm pool is disabled." (NOT "gate holding".) ✅ Pass.

- [x] **Scenario: decideVerdict unit tests cover all 5 branches**
  **Method:** CLI
  **Steps:**
  1. Run `npm test`
  - [x] **Expected:** New file `tests/verify-pool-logic.test.ts` reports 9 passing tests covering: nominal hit, gate-broken (2×), no-workers, ambiguous count, expected===0 cases, full-fingerprint regression in error message, and PGREP_PATTERN constant. ✅ Pass — 31 files / 652 tests (was 30 / 643).

- [x] **Scenario: ENOENT handling (pgrep missing from PATH)**
  **Method:** Code review (CLI test couldn't reliably reproduce without breaking the harness)
  **Steps:**
  1. Inspect `countProcesses` in `scripts/verify-pool-logic.mjs`
  - [x] **Expected:** Explicit branch for `result.error?.code === "ENOENT"` throws a `PgrepUnavailableError`-equivalent; the CLI catches `e.code === "PGREP_NOT_FOUND"` and exits 2 with a clear message. ✅ Pass — verified by code reading; spawnSync's ENOENT-on-error contract is documented in Node's child_process API.

- [x] **Scenario: tsc + vitest still pass**
  **Method:** CLI
  **Steps:**
  1. `npx tsc --noEmit`
  2. `npm test`
  - [x] **Expected:** Both pass. ✅ Pass — `TypeScript: No errors found`; `31 passed (31) / 652 passed (652)`.

### Incomplete scenarios (user-approved)

- ⚠️ **upstream-watch.yml end-to-end run** — Only triggerable via merged-main or `workflow_dispatch`. Defer to post-merge `gh workflow run upstream-watch.yml`. **Risk accepted:** the dedup-step fix was empirically reproduced both as a failing baseline and a passing fixed form; the YAML is structurally valid (no other steps changed besides comment additions, `set -eo pipefail`, and the `cat | tr` simplification).

## Follow-ups (not in this PR)

- Wire `verify:pool` into a CI workflow that runs on a schedule and pages on regression. Would need a runner that spawns the warm pool — non-trivial; track separately if appetite exists.
- Investigate the `--max-old-space-size=9999` workers observed during local verification — these aren't from this codebase (we don't pass that flag).
- Consider extracting the spawn-args fingerprint into a single exported constant in `cli-capabilities.ts` so the warm-pool args, orphan-reaper signature, and `PGREP_PATTERN` couple at compile time rather than via comment.
- `actions/checkout` version inconsistency: only `upstream-watch.yml` is at v6; `ci.yml`, `publish.yml`, `release-please.yml` are still at v4. Worth a separate sweep PR.

Closes #104
