### PR TITLE
docs(readme): cross-agent pair-review framing + architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ The interesting engineering is the boring stuff: warm process pools so the 12-se
 flowchart LR
     A[Claude Code / Codex<br/>or any MCP host] -->|MCP tool call| B[gemini-cli-mcp]
     B <-->|read/write turns| D[(SQLite<br/>session store)]
-    B -->|borrow worker| C[Warm process pool]
-    C -->|stream-json over stdio| E[gemini CLI subprocess]
+    B -->|acquire worker| C[Warm process pool]
+    C -.-|manages| E[gemini CLI subprocess]
+    B <-->|stream-json over stdio| E
     E -->|HTTPS| F[Google Gemini API]
 ```
 
-The MCP server keeps a small pool of pre-spawned `gemini` CLI processes hot, so the first request after server start typically responds in 4–5 s instead of the 12 s a cold spawn would take. Multi-turn history is stored in SQLite (`node:sqlite`, no native deps) and replayed as structured context on every `gemini-reply`.
+The MCP server keeps a small pool of pre-spawned `gemini` CLI processes hot, so a request typically completes in ~4–5 s instead of ~17 s — eliminating the ~12 s cold-start overhead. Multi-turn history is stored in SQLite (`node:sqlite`, no native deps) and replayed as structured context on every `gemini-reply`.
 
 ## Quick Setup (recommended)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,30 @@
 [![CI](https://github.com/guibarscevicius/gemini-cli-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/guibarscevicius/gemini-cli-mcp/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-An MCP server that wraps the official [`@google/gemini-cli`](https://github.com/google-gemini/gemini-cli), exposing Gemini to Claude Code and any MCP-compatible host. Supports stateful multi-turn sessions, async jobs, response streaming, and a warm process pool for low-latency responses.
+Use Gemini's free tier as an on-demand code reviewer from inside Claude Code, Codex, or any MCP-compatible host. `gemini-cli-mcp` wraps the official [`@google/gemini-cli`](https://github.com/google-gemini/gemini-cli) and exposes it through the Model Context Protocol — so you can ask Gemini to second-opinion a diff, pair-review a refactor, or scan a long file without leaving your primary agent.
+
+Stateful multi-turn sessions, async jobs, response streaming, and a warm process pool keep latency low enough to be worth using.
+
+## Why I built this
+
+I use Claude Code and Codex daily for real work, and I have free Gemini access through my employer. Gemini is genuinely good at long-context reading and at noticing things a different model would miss — but switching tabs to ask it costs flow.
+
+So I made it a tool call. Now my primary agent can hand Gemini a diff, a directory, or a question and keep going. It's not a replacement for either model — it's a cheap second opinion, on demand, in the same loop.
+
+The interesting engineering is the boring stuff: warm process pools so the 12-second cold start doesn't stall the agent, SQLite-backed sessions so multi-turn actually works, and a workspace-scoped `@file` expander so you can hand Gemini a whole subdirectory in one prompt.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    A[Claude Code / Codex<br/>or any MCP host] -->|MCP tool call| B[gemini-cli-mcp]
+    B <-->|read/write turns| D[(SQLite<br/>session store)]
+    B -->|borrow worker| C[Warm process pool]
+    C -->|stream-json over stdio| E[gemini CLI subprocess]
+    E -->|HTTPS| F[Google Gemini API]
+```
+
+The MCP server keeps a small pool of pre-spawned `gemini` CLI processes hot, so the first request after server start typically responds in 4–5 s instead of the 12 s a cold spawn would take. Multi-turn history is stored in SQLite (`node:sqlite`, no native deps) and replayed as structured context on every `gemini-reply`.
 
 ## Quick Setup (recommended)
 
@@ -371,6 +394,13 @@ const { response } = await gemini_reply({
 The server pre-spawns Gemini CLI processes (warm pool) to eliminate the ~12 s cold-start cost. First requests arrive in ~4–5 s once the pool has warmed up (~12 s after server start).
 
 Set `GEMINI_POOL_STARTUP_MS` to match your machine's CLI startup time. Disable the pool with `GEMINI_POOL_ENABLED=0` for debugging.
+
+## Limitations
+
+- **Free-tier rate limits apply** — Google's quotas govern, not this server. Heavy parallel workloads (`gemini-batch` with many prompts) will hit them; tune `GEMINI_MAX_CONCURRENT` accordingly.
+- **Cold-start latency on first request** — the first prompt after server start waits up to ~12 s for a warm-pool slot. Subsequent requests are ~4–5 s.
+- **No streaming pass-through to the host** — responses are accumulated and returned whole. Async jobs let you poll for partial output, but there's no token-by-token stream into Claude Code/Codex (the MCP spec doesn't expose one yet).
+- **Requires an authenticated `gemini` CLI on the same machine** — the server shells out to the official CLI, so OAuth state lives in `~/.config/gemini`. This is not a remote API client; if you need that, talk to the Gemini API directly.
 
 ## Environment variables
 


### PR DESCRIPTION
## Summary

Portfolio polish for the README — a one-pass reframe from mechanism-first ("an MCP server that wraps…") to use-case-first ("Gemini as on-demand code reviewer from Claude Code/Codex"). Adds three new sections above the fold and a Limitations section below Performance.

Tracks `guibarscevicius/job-search#49` Phases 1, 2, and 4. Screencast (Phase 3) deferred to a separate task.

## Changes

- **Opening rewritten** — leads with the cross-agent pair-review story, drops the technical wrapper description into a supporting role.
- **New "Why I built this" section** — personal rationale tying to the daily Claude Code/Codex workflow and free Gemini access.
- **New "Architecture" section with Mermaid diagram** — renders inline on GitHub. Shows host → MCP → server → warm pool / subprocess / SQLite session store / Gemini API.
- **New "Limitations" section** — credibility signal: rate limits, cold-start latency, no streaming pass-through, requires local authenticated CLI.
- **GitHub topics set via `gh repo edit`** (out-of-diff): `mcp`, `model-context-protocol`, `claude-code`, `gemini`, `gemini-cli`, `ai-tooling`, `code-review`, `typescript`.

## Review fixes (Gemini dual-review pass)

- **Latency claim corrected** — was conflating "12 s cold-spawn total" with "12 s savings"; actual cold-spawn total is ~17 s per `src/warm-pool.ts:19-20`. Rephrased to "~4–5 s instead of ~17 s — eliminating the ~12 s cold-start overhead."
- **Mermaid edges refined** — pool now `-.-|manages|` subprocess (dotted ownership edge); stream-json flows directly between server and subprocess (`B <-->|stream-json over stdio| E`). Validated with local `mmdc` render.

## Out of scope (deliberate)

- **Screencast** — issue #49 Phase 3. Separate task; doesn't block the text/diagram changes.
- **Blog post** — issue #54. Depends on this PR's diagram landing first.
- **LinkedIn re-add** — issue #62 is a trigger-condition issue (≥30 stars / 2+ public MCPs / external mentions). Nothing to deliver here.

## Test plan

### Impact coverage audit
- [x] Diff is README-only (1 file, +34 / −4 lines) — no source or test changes
- [x] No internal anchor links in README (all `[text](#anchor)` patterns are absent); section headings preserved

### Documentation
- [x] README opening reframed (use-case-first)
- [x] "Why I built this" section added
- [x] "Architecture" section with Mermaid diagram added
- [x] "Limitations" section added

### Functional scenarios
- [x] **Mermaid diagram syntax valid** — Method: `npx mmdc -i diagram.mmd -o diagram.svg`. Steps: extract fenced ```mermaid block, render to SVG. Expected: exit 0, SVG produced. Result: 18.5KB SVG, exit 0.
- [x] **`npm run build` passes** — Method: run from main worktree. Expected: `tsc && chmod +x dist/index.js` exits 0. Result: clean.
- [x] **`npm test` passes** — Method: full vitest suite. Expected: all green. Result: 652 / 652 passed across 31 files.
- [x] **GitHub topics applied** — Method: `gh repo view --json repositoryTopics`. Expected: 8 topics present. Result: `ai-tooling`, `claude-code`, `code-review`, `gemini`, `gemini-cli`, `mcp`, `model-context-protocol`, `typescript` all listed.
- [x] **Factual accuracy of new prose** — Method: Gemini dual-review pass cross-referencing claims against source (`src/warm-pool.ts`, `src/session-store.ts`, `src/gemini-runner.ts`, `package.json`). Expected: 0 critical findings. Result: 1 IMPORTANT (latency conflation) + 1 SUGGESTION (diagram edge) — both fixed in 2nd commit.

## AI Review Notes

Gemini reviewed the README prose against the codebase via `mcp__plugin_gemini_gemini__ask-gemini` (model `gemini-3-flash-preview`, single-file holistic review since this is a docs-only diff). Key findings:

- **Approved with minor prose tweaks.** Core technical claims (security, env isolation, session persistence, `@file` workspace boundary) all verified against source.
- **IMPORTANT (fixed):** Latency phrasing conflated savings with cold-spawn total — corrected.
- **SUGGESTION (fixed):** Mermaid arrow direction was misleading — refined.
- **SUGGESTION (skipped):** First-person voice in "Why I built this" — Gemini explicitly preferred the personal touch for a portfolio repo. User confirmed during pre-draft sign-off.