### PR TITLE
feat(warm-pool): bound per-instance cost — lower default size + idle eviction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,10 @@ Use `mcp__gemini-dev__*` tools (not `mcp__gemini__*` which hit the installed rel
 | `GEMINI_CACHE_TTL_MS` | `300000` | Response cache TTL (ms); `0` = disabled |
 | `GEMINI_CACHE_MAX_ENTRIES` | `50` | Max entries in the response cache |
 | `GEMINI_POOL_ENABLED` | `1` | `0` = disable warm pool (cold spawn only, for debugging) |
-| `GEMINI_POOL_SIZE` | `GEMINI_MAX_CONCURRENT` | Number of pre-spawned warm processes |
+| `GEMINI_POOL_SIZE` | `1` | Number of pre-spawned warm processes per server. Combined with idle eviction, larger values are safe. |
 | `GEMINI_POOL_STARTUP_MS` | `12000` | Estimated CLI startup time (ms); prompt writes delayed until this age after spawn |
+| `GEMINI_POOL_IDLE_TIMEOUT_MS` | `300000` | Time of no `acquire()` calls after which the pool shrinks to `GEMINI_POOL_MIN_SIZE`. `0` = disabled. |
+| `GEMINI_POOL_MIN_SIZE` | `0` | Floor the pool can shrink to during idle eviction. Must be ≤ `GEMINI_POOL_SIZE`. |
 | `GEMINI_BINARY` | (auto-discovered) | Explicit path to the `gemini` binary. When set, auto-discovery is skipped. Useful for nvm/fnm users where gemini isn't on the MCP server's PATH. |
 | `GEMINI_JOB_TTL_MS` | `300000` | How long completed/failed/cancelled jobs are retained in memory (ms) |
 | `GEMINI_JOB_GC_MS` | `60000` | Job garbage-collection sweep interval (ms) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ Use `mcp__gemini-dev__*` tools (not `mcp__gemini__*` which hit the installed rel
 4. `gemini-cancel` — start a job, cancel it, verify status becomes `cancelled`
 5. `@file` reference in prompt — verifies file expansion end-to-end (use a file in `src/`)
 6. Two concurrent `ask-gemini` calls — verifies semaphore and warm pool under load
+7. Idle eviction (PR #112) — start with `GEMINI_POOL_SIZE=2 GEMINI_POOL_IDLE_TIMEOUT_MS=15000 GEMINI_POOL_MIN_SIZE=0`. Run `pgrep -af "gemini --yolo"`: 2 workers → 0 after 20 s idle → 1 after a fresh `ask-gemini` call → second call within 15 s hits warm. Verifies the eviction + replenishment loop end-to-end.
 
 **After a PR adds new features**, add the relevant scenario(s) to the list above and to the PR test plan.
 

--- a/README.md
+++ b/README.md
@@ -396,6 +396,18 @@ The server pre-spawns Gemini CLI processes (warm pool) to eliminate the ~12 s co
 
 Set `GEMINI_POOL_STARTUP_MS` to match your machine's CLI startup time. Disable the pool with `GEMINI_POOL_ENABLED=0` for debugging.
 
+### Per-instance cost
+
+Every MCP client (each Claude Code window, Codex CLI session, editor, etc.) spawns its own `gemini-cli-mcp` server, and each server keeps its own warm pool. The total warm-process count on the box is roughly:
+
+```
+warm workers ≈ (open MCP clients) × (gemini-cli-mcp configs per client) × GEMINI_POOL_SIZE
+```
+
+Defaults are tuned for the multi-instance common case: `GEMINI_POOL_SIZE=1` keeps a single warm slot per server, and `GEMINI_POOL_IDLE_TIMEOUT_MS=300000` evicts idle workers down to `GEMINI_POOL_MIN_SIZE=0` after 5 min — so a developer with several open editors does not pay for warm pools they aren't using.
+
+If you raise `GEMINI_POOL_SIZE` above 1 for parallel batch work (`gemini-batch`, concurrent reviews), idle eviction reclaims the cost during quiet windows. To keep N slots permanently warm, set `GEMINI_POOL_MIN_SIZE=N`. To disable eviction entirely, set `GEMINI_POOL_IDLE_TIMEOUT_MS=0`.
+
 ## Limitations
 
 - **Free-tier rate limits apply** — Google's quotas govern, not this server. Heavy parallel workloads (`gemini-batch` with many prompts) will hit them; tune `GEMINI_MAX_CONCURRENT` accordingly.
@@ -419,8 +431,10 @@ All variables are optional.
 | `GEMINI_CACHE_TTL_MS` | `300000` | Response cache TTL (ms). `0` = disabled. |
 | `GEMINI_CACHE_MAX_ENTRIES` | `50` | Max entries in the response cache. |
 | `GEMINI_POOL_ENABLED` | `1` | `0` = disable warm pool (cold spawn only). |
-| `GEMINI_POOL_SIZE` | `GEMINI_MAX_CONCURRENT` | Number of pre-spawned warm processes. |
+| `GEMINI_POOL_SIZE` | `1` | Number of pre-spawned warm processes per server. See [Per-instance cost](#per-instance-cost) before raising. |
 | `GEMINI_POOL_STARTUP_MS` | `12000` | Estimated CLI startup time (ms). Prompt writes are delayed by this amount after spawn. |
+| `GEMINI_POOL_IDLE_TIMEOUT_MS` | `300000` | Time of no `acquire()` calls after which the pool shrinks to `GEMINI_POOL_MIN_SIZE`. `0` disables eviction. |
+| `GEMINI_POOL_MIN_SIZE` | `0` | Floor the pool can shrink to during idle eviction. Must be ≤ `GEMINI_POOL_SIZE`. |
 | `GEMINI_BINARY` | (auto-discovered) | Explicit path to the `gemini` binary. When set, auto-discovery is skipped entirely. Useful when gemini is installed via nvm/fnm and not on the PATH that MCP servers see. |
 | `GEMINI_JOB_TTL_MS` | `300000` | How long completed/failed/cancelled jobs are retained (ms). |
 | `GEMINI_JOB_GC_MS` | `60000` | Job garbage-collection interval (ms). |

--- a/docs/research/2026-05-09-warm-pool-per-instance-cost.md
+++ b/docs/research/2026-05-09-warm-pool-per-instance-cost.md
@@ -1,0 +1,96 @@
+# Warm pool isolation across MCP server instances
+
+**Date:** 2026-05-09
+**Status:** Findings — issues filed (#110 phase 1, #111 phase 2)
+**Triggered by:** "we launch one warmup per claude code / codex instance ... check if this should be one process only, or if it already reuses the processing across claude code / codex / mcp instances"
+
+## TL;DR
+
+- **No reuse today.** Every MCP client (Claude Code window, Codex CLI invocation, Cursor, etc.) spawns its own `gemini-cli-mcp` child process via stdio. Each child instantiates its own `WarmProcessPool` singleton. Pools never communicate.
+- On this machine right now: **~13 MCP server processes**, **~14 warm `gemini --yolo` workers** running in parallel. With pool size 2 and ~250–400 MB resident per worker that is **3–5 GB of RAM** held by idle pools, plus a 5 s keepalive heartbeat per worker.
+- Per-instance redundancy is forced by the architecture, not a bug. Stdio MCP transport is inherently 1:1 client↔server. Sharing requires HTTP/SSE transport or an out-of-band daemon.
+- **User-approved direction:** "Bound cost, don't share." Lower default footprint and document the multiplication. Architectural rework (HTTP singleton or daemon) deferred.
+- **Side investigation closed:** The "doubled relaunch" workers I observed via `pgrep -af "gemini --yolo"` are exclusively from MCP servers started **before today's 06:46 npx-cache refresh**. All post-0.8.0 servers correctly inject `GEMINI_CLI_NO_RELAUNCH=true` and run 1 process per pool slot. Issue #98 contract holds in 0.8.0.
+
+## Architecture confirmation
+
+### Why each instance has its own pool
+
+1. `src/index.ts:228` uses `StdioServerTransport`. MCP stdio is 1:1: each client spawns the server as a child and talks over its stdin/stdout. There is no daemon, broker, or socket.
+2. `src/gemini-runner.ts:163` declares `export let warmPool: WarmProcessPool | null = null` — a module-level singleton, scoped to the Node process.
+3. `src/gemini-runner.ts:219` constructs the pool exactly once at module init.
+4. Multiplicity factor:
+   - 1 client × 1 MCP entry → 1 server, 1 pool
+   - 1 client × 2 MCP entries (e.g. `gemini` + `gemini-dev` for hands-on testing in this repo's `.mcp.json`) → 2 servers, 2 pools
+   - N clients (parallel Claude Code windows, sprint mode, Codex sessions) × M entries → N×M pools
+
+### What IS shared today
+
+- `~/.gemini-cli-mcp/sessions.db` (SQLite) — multi-turn session state. A session started under one MCP server can be continued through another (the new server reads the same DB). This is the only cross-instance state.
+
+### What COULD be shared (not implemented)
+
+| Approach | Sketch | Status |
+|---|---|---|
+| HTTP/SSE singleton | Switch transport to `StreamableHTTPServerTransport`, leader-elect on Unix socket / 127.0.0.1, clients connect over HTTP. Stock MCP. | Deferred — significant lifecycle / auth / observability work. |
+| Out-of-band pool daemon | Keep stdio MCP server thin, factor pool into a separate `gemini-cli-mcp-poold` over a Unix socket. | Deferred — adds a second binary and protocol. |
+| Bound cost (chosen) | Reduce per-instance footprint, document multiplication. | **Approved.** Scope below. |
+
+## Empirical evidence
+
+### Current process count (snapshot at ~07:37 local)
+
+| Group | Count | Notes |
+|---|---|---|
+| `npm exec @guibarscevicius/gemini-cli-mcp` parents | 8 | Each is a Claude Code child via npx |
+| MCP server Node processes (`node .../bin/gemini-cli-mcp`) | 13 | Includes long-lived `npx`-resolved binaries |
+| `gemini --yolo --output-format stream-json` workers | ~14 | Counts double for pre-0.8.0 servers (relaunch) |
+
+### Relaunch suppression validation (issue #98)
+
+Tested per-server by reading `/proc/<pid>/environ`:
+
+- Pre-0.8.0 servers (started before 06:46:15 cache refresh): outer worker has **no** `GEMINI_CLI_NO_RELAUNCH`; inner worker (relaunched with `--max-old-space-size=9999`) has it set by the relaunch code itself.
+- Post-0.8.0 servers (started after 06:46:15): outer worker has `GEMINI_CLI_NO_RELAUNCH=true`. **Only one process per pool slot.** No relaunch.
+
+**Verdict:** 0.8.0 is correct. The doubling visible in `pgrep` output is purely from stale pre-upgrade MCP servers still alive. Closing the relaunch question.
+
+## Approved direction: bound cost
+
+The user picked option A: lower per-instance footprint, document, no sharing rework.
+
+### Cost model to communicate
+
+```
+warm workers = N_clients × M_entries × GEMINI_POOL_SIZE
+             ≈ (open Claude Code windows) × (gemini-cli-mcp configs) × pool_size
+```
+
+Today's defaults: `GEMINI_POOL_SIZE = GEMINI_MAX_CONCURRENT = 2`.
+With 5 active Claude Code sessions and one MCP entry: **10 workers, ~2.5–4 GB RAM**.
+
+### Sub-options for the "bound cost" PR
+
+These are the concrete moves available; pick one or combine.
+
+| # | Change | Pros | Cons |
+|---|---|---|---|
+| **B1** | Default `GEMINI_POOL_SIZE` from `MAX_CONCURRENT` (2) → `1`. | Cuts steady-state RAM in half. One-line change + docs. | When 2 concurrent prompts arrive, the second cold-spawns (~13 s wait, defeating the pool for the 2nd). Hits parallel reviews and `gemini-batch`. |
+| **B2** | Add idle eviction: pool shrinks to 0 (or to a `MIN_POOL_SIZE`) after `IDLE_TIMEOUT_MS` of no acquires; replenishes lazily on the next request. | Pays cost only when actively used. Honest match to "warm cache" semantics. | Adds state machine + tests. First request after idle cold-spawns. Requires a way to mark "active" cleanly. |
+| **B3** | Detect multi-instance scenarios and warn at startup (e.g. "another `gemini-cli-mcp` already running on this user — consider lowering `GEMINI_POOL_SIZE`"). | Zero behavior change; informs heavy users. | Detection is heuristic (`pgrep` against own user); no automatic action. |
+| **B4** | Document only: README section on per-instance cost, recommended overrides for sprint/multi-session workflows (`GEMINI_POOL_SIZE=1`, `GEMINI_POOL_ENABLED=0` for sleep windows). | No code risk. | Users have to read and act. |
+
+### Recommended bundle
+
+**B2 + B4** — idle eviction is the most elegant fix because it makes the pool's cost match its actual utility. B1 alone is a too-blunt regression for active users. B4 captures the operator-facing story regardless of which code change ships. B3 is optional polish.
+
+If idle eviction feels too risky for a single PR, a phased plan:
+
+- **Phase 1 (one PR):** B1 + B4. Lower default, document, accept the cold-start cost for parallel calls. Ship in a minor version bump.
+- **Phase 2 (follow-up issue):** B2. Add idle eviction so pool size 2 becomes safe again.
+
+## Open questions for issue creation
+
+1. Which sub-option(s) — B1, B2, B3, B4, or a bundle — should become GitHub issues?
+2. Should the cost-model documentation live in README (alongside the env-var table) or in a separate `docs/operations.md`?
+3. Is the deferred "shared pool" track (HTTP singleton / daemon) worth a tracking issue with `Research:` / `Evaluate:` prefix, or close cleanly with a pointer to this doc?

--- a/docs/research/2026-05-09-warm-pool-per-instance-cost.md
+++ b/docs/research/2026-05-09-warm-pool-per-instance-cost.md
@@ -66,8 +66,12 @@ warm workers = N_clients × M_entries × GEMINI_POOL_SIZE
              ≈ (open Claude Code windows) × (gemini-cli-mcp configs) × pool_size
 ```
 
-Today's defaults: `GEMINI_POOL_SIZE = GEMINI_MAX_CONCURRENT = 2`.
+Pre-PR defaults (snapshot at time of writing): `GEMINI_POOL_SIZE = GEMINI_MAX_CONCURRENT = 2`.
 With 5 active Claude Code sessions and one MCP entry: **10 workers, ~2.5–4 GB RAM**.
+
+> **Update — PR #112 merged:** the new default is `GEMINI_POOL_SIZE = 1` with idle eviction enabled
+> (`GEMINI_POOL_IDLE_TIMEOUT_MS = 300000`, `GEMINI_POOL_MIN_SIZE = 0`). Same scenario now: **5 workers
+> active under load, drops to 0 after 5 min idle.**
 
 ### Sub-options for the "bound cost" PR
 

--- a/docs/research/2026-05-09-warm-pool-per-instance-cost.md
+++ b/docs/research/2026-05-09-warm-pool-per-instance-cost.md
@@ -1,7 +1,7 @@
 # Warm pool isolation across MCP server instances
 
 **Date:** 2026-05-09
-**Status:** Findings — issues filed (#110 phase 1, #111 phase 2)
+**Status:** Findings — both phases bundled in PR [#112](https://github.com/guibarscevicius/gemini-cli-mcp/pull/112) (closes #110 + #111)
 **Triggered by:** "we launch one warmup per claude code / codex instance ... check if this should be one process only, or if it already reuses the processing across claude code / codex / mcp instances"
 
 ## TL;DR

--- a/src/gemini-runner.ts
+++ b/src/gemini-runner.ts
@@ -96,13 +96,42 @@ const semaphore = new Semaphore(MAX_CONCURRENT);
 // forward the @file token to the CLI for workspace-aware resolution).
 //
 // Env vars:
-//   GEMINI_POOL_ENABLED     "1" (default) | "0" to disable
-//   GEMINI_POOL_SIZE        default = GEMINI_MAX_CONCURRENT
-//   GEMINI_POOL_STARTUP_MS  estimated CLI startup time; prompt writes are delayed until this
-//                           many ms after spawn so the CLI is ready to process input (default 12000)
+//   GEMINI_POOL_ENABLED          "1" (default) | "0" to disable
+//   GEMINI_POOL_SIZE             default = 1 (one warm slot per server; idle eviction lets
+//                                larger values relax during quiet windows)
+//   GEMINI_POOL_STARTUP_MS       estimated CLI startup time; prompt writes are delayed until this
+//                                many ms after spawn so the CLI is ready to process input (default 12000)
+//   GEMINI_POOL_IDLE_TIMEOUT_MS  shrink the pool to GEMINI_POOL_MIN_SIZE after this many ms with no
+//                                acquire() calls (default 300000 = 5 min; 0 disables eviction)
+//   GEMINI_POOL_MIN_SIZE         floor the pool can shrink to during idle eviction (default 0,
+//                                must be ≤ GEMINI_POOL_SIZE)
 const POOL_ENABLED = (process.env.GEMINI_POOL_ENABLED ?? "1") !== "0";
-const POOL_SIZE = parseInt(process.env.GEMINI_POOL_SIZE ?? String(MAX_CONCURRENT), 10);
+const POOL_SIZE = parseInt(process.env.GEMINI_POOL_SIZE ?? "1", 10);
+if (!Number.isFinite(POOL_SIZE) || POOL_SIZE < 1) {
+  throw new Error(
+    `GEMINI_POOL_SIZE must be a positive integer, got "${process.env.GEMINI_POOL_SIZE}". ` +
+      "Use 1 (default) for minimal footprint, or a larger value combined with idle eviction."
+  );
+}
 const POOL_STARTUP_MS = parseInt(process.env.GEMINI_POOL_STARTUP_MS ?? "12000", 10);
+const POOL_IDLE_TIMEOUT_MS = parseInt(process.env.GEMINI_POOL_IDLE_TIMEOUT_MS ?? "300000", 10);
+if (!Number.isFinite(POOL_IDLE_TIMEOUT_MS) || POOL_IDLE_TIMEOUT_MS < 0) {
+  throw new Error(
+    `GEMINI_POOL_IDLE_TIMEOUT_MS must be a non-negative integer, got "${process.env.GEMINI_POOL_IDLE_TIMEOUT_MS}". ` +
+      "Use 0 to disable idle eviction or a positive value (ms) to enable."
+  );
+}
+const POOL_MIN_SIZE = parseInt(process.env.GEMINI_POOL_MIN_SIZE ?? "0", 10);
+if (!Number.isFinite(POOL_MIN_SIZE) || POOL_MIN_SIZE < 0) {
+  throw new Error(
+    `GEMINI_POOL_MIN_SIZE must be a non-negative integer, got "${process.env.GEMINI_POOL_MIN_SIZE}".`
+  );
+}
+if (POOL_MIN_SIZE > POOL_SIZE) {
+  throw new Error(
+    `GEMINI_POOL_MIN_SIZE (${POOL_MIN_SIZE}) cannot exceed GEMINI_POOL_SIZE (${POOL_SIZE}).`
+  );
+}
 
 function readdirSafe(dir: string): string[] {
   try {
@@ -217,7 +246,7 @@ if (POOL_ENABLED && !SETUP_MODE) {
   // PGREP_PATTERN in scripts/verify-pool-logic.mjs. If you change them, update
   // all three sites — there's no automated coupling.
   warmPool = new WarmProcessPool(
-    Number.isFinite(POOL_SIZE) && POOL_SIZE >= 1 ? POOL_SIZE : MAX_CONCURRENT,
+    POOL_SIZE,
     ["--yolo", "--output-format", "stream-json"],
     {
       HOME: process.env.HOME ?? "",
@@ -225,7 +254,9 @@ if (POOL_ENABLED && !SETUP_MODE) {
       ...GEMINI_CHILD_ENV_OVERRIDES,
     },
     effectiveStartupMs,
-    GEMINI_BINARY
+    GEMINI_BINARY,
+    POOL_IDLE_TIMEOUT_MS,
+    POOL_MIN_SIZE
   );
 }
 

--- a/src/gemini-runner.ts
+++ b/src/gemini-runner.ts
@@ -107,30 +107,34 @@ const semaphore = new Semaphore(MAX_CONCURRENT);
 //                                must be ≤ GEMINI_POOL_SIZE)
 const POOL_ENABLED = (process.env.GEMINI_POOL_ENABLED ?? "1") !== "0";
 const POOL_SIZE = parseInt(process.env.GEMINI_POOL_SIZE ?? "1", 10);
-if (!Number.isFinite(POOL_SIZE) || POOL_SIZE < 1) {
-  throw new Error(
-    `GEMINI_POOL_SIZE must be a positive integer, got "${process.env.GEMINI_POOL_SIZE}". ` +
-      "Use 1 (default) for minimal footprint, or a larger value combined with idle eviction."
-  );
-}
 const POOL_STARTUP_MS = parseInt(process.env.GEMINI_POOL_STARTUP_MS ?? "12000", 10);
 const POOL_IDLE_TIMEOUT_MS = parseInt(process.env.GEMINI_POOL_IDLE_TIMEOUT_MS ?? "300000", 10);
-if (!Number.isFinite(POOL_IDLE_TIMEOUT_MS) || POOL_IDLE_TIMEOUT_MS < 0) {
-  throw new Error(
-    `GEMINI_POOL_IDLE_TIMEOUT_MS must be a non-negative integer, got "${process.env.GEMINI_POOL_IDLE_TIMEOUT_MS}". ` +
-      "Use 0 to disable idle eviction or a positive value (ms) to enable."
-  );
-}
 const POOL_MIN_SIZE = parseInt(process.env.GEMINI_POOL_MIN_SIZE ?? "0", 10);
-if (!Number.isFinite(POOL_MIN_SIZE) || POOL_MIN_SIZE < 0) {
-  throw new Error(
-    `GEMINI_POOL_MIN_SIZE must be a non-negative integer, got "${process.env.GEMINI_POOL_MIN_SIZE}".`
-  );
-}
-if (POOL_MIN_SIZE > POOL_SIZE) {
-  throw new Error(
-    `GEMINI_POOL_MIN_SIZE (${POOL_MIN_SIZE}) cannot exceed GEMINI_POOL_SIZE (${POOL_SIZE}).`
-  );
+// Validate pool config only when the pool is enabled — disabled-pool users with
+// stale/invalid GEMINI_POOL_* env vars must not crash the server.
+if (POOL_ENABLED) {
+  if (!Number.isFinite(POOL_SIZE) || POOL_SIZE < 1) {
+    throw new Error(
+      `GEMINI_POOL_SIZE must be a positive integer, got "${process.env.GEMINI_POOL_SIZE}". ` +
+        "Use 1 (default) for minimal footprint, or a larger value combined with idle eviction."
+    );
+  }
+  if (!Number.isFinite(POOL_IDLE_TIMEOUT_MS) || POOL_IDLE_TIMEOUT_MS < 0) {
+    throw new Error(
+      `GEMINI_POOL_IDLE_TIMEOUT_MS must be a non-negative integer, got "${process.env.GEMINI_POOL_IDLE_TIMEOUT_MS}". ` +
+        "Use 0 to disable idle eviction or a positive value (ms) to enable."
+    );
+  }
+  if (!Number.isFinite(POOL_MIN_SIZE) || POOL_MIN_SIZE < 0) {
+    throw new Error(
+      `GEMINI_POOL_MIN_SIZE must be a non-negative integer, got "${process.env.GEMINI_POOL_MIN_SIZE}".`
+    );
+  }
+  if (POOL_MIN_SIZE > POOL_SIZE) {
+    throw new Error(
+      `GEMINI_POOL_MIN_SIZE (${POOL_MIN_SIZE}) cannot exceed GEMINI_POOL_SIZE (${POOL_SIZE}).`
+    );
+  }
 }
 
 function readdirSafe(dir: string): string[] {
@@ -308,12 +312,13 @@ export function getEnvOverrides(): Record<string, unknown> {
   if (process.env.GEMINI_POOL_ENABLED !== undefined && POOL_ENABLED !== true) {
     overrides.GEMINI_POOL_ENABLED = POOL_ENABLED;
   }
-  if (process.env.GEMINI_POOL_SIZE !== undefined) {
-    const effectivePoolSize = Number.isFinite(POOL_SIZE) && POOL_SIZE >= 1 ? POOL_SIZE : MAX_CONCURRENT;
-    if (effectivePoolSize !== MAX_CONCURRENT) {
-      overrides.GEMINI_POOL_SIZE = effectivePoolSize;
-    }
+  if (process.env.GEMINI_POOL_SIZE !== undefined && POOL_SIZE !== 1) {
+    overrides.GEMINI_POOL_SIZE = POOL_SIZE;
   }
+  const poolIdleTimeoutOverride = parseIntOverride("GEMINI_POOL_IDLE_TIMEOUT_MS", 300000);
+  if (poolIdleTimeoutOverride !== undefined) overrides.GEMINI_POOL_IDLE_TIMEOUT_MS = poolIdleTimeoutOverride;
+  const poolMinSizeOverride = parseIntOverride("GEMINI_POOL_MIN_SIZE", 0);
+  if (poolMinSizeOverride !== undefined) overrides.GEMINI_POOL_MIN_SIZE = poolMinSizeOverride;
   const poolStartupOverride = parseIntOverride("GEMINI_POOL_STARTUP_MS", 12000);
   if (poolStartupOverride !== undefined) overrides.GEMINI_POOL_STARTUP_MS = poolStartupOverride;
 

--- a/src/warm-pool.ts
+++ b/src/warm-pool.ts
@@ -245,16 +245,23 @@ export class WarmProcessPool {
    * Evict ready processes down to `minSize` if the pool has been idle for at
    * least `idleTimeoutMs`. Called by the idle-check interval.
    *
-   * `evicting` is set during the kill loop so the per-process `exit` listener
-   * (which would otherwise spawn a replacement at the bottom of `_spawnAndEnqueue`)
-   * stays quiet — without it the killed worker's exit event would race the
-   * eviction loop and respawn what we just killed.
+   * The eviction loop is fully synchronous. Two layers of defense prevent the
+   * killed workers from being respawned:
+   *  1. Primary: `ready.shift()` removes the entry BEFORE `killGroup`, so when
+   *     the async `exit` event fires later, `onExitOrError` finds `idx === -1`
+   *     and skips its replenishment branch.
+   *  2. Secondary: the `evicting` flag suppresses the spawn that `acquire()`
+   *     would otherwise trigger on an empty pool — without it, an `acquire()`
+   *     racing the kill loop would immediately respawn what we just removed.
+   * The flag is set/cleared inside `try/finally` so an exception in `killGroup`
+   * cannot leave the pool stuck in `evicting === true`.
    */
   private _evictIfIdle(): void {
     if (this.draining) return;
     if (Date.now() - this.lastAcquireAt < this.idleTimeoutMs) return;
     if (this.ready.length <= this.minSize) return;
 
+    const before = this.ready.length;
     this.evicting = true;
     try {
       while (this.ready.length > this.minSize) {
@@ -267,6 +274,12 @@ export class WarmProcessPool {
     } finally {
       this.evicting = false;
     }
+    mcpLog("info", "pool", {
+      event: "idle_eviction",
+      evicted: before - this.ready.length,
+      remaining: this.ready.length,
+      idleMs: Date.now() - this.lastAcquireAt,
+    });
   }
 
   /** Kill all ready processes and reject all pending waiters (graceful shutdown). */

--- a/src/warm-pool.ts
+++ b/src/warm-pool.ts
@@ -49,33 +49,57 @@ export class WarmProcessPool {
   private readonly ready: ReadyEntry[] = [];
   private readonly waiters: Waiter[] = [];
   private draining = false;
+  private evicting = false;
   private consecutiveSpawnFailures = 0;
   private lastSpawnError: string | null = null;
+  private lastAcquireAt: number = Date.now();
+  private idleTimer: ReturnType<typeof setInterval> | null = null;
   private static readonly MAX_CONSECUTIVE_FAILURES = 5;
 
   /**
-   * @param poolSize   Number of processes to keep warm (default: GEMINI_MAX_CONCURRENT).
-   * @param baseArgs   Args to pass to every spawned `gemini` process (no --prompt).
-   * @param env        Restricted env for the subprocess (HOME + PATH).
-   * @param startupMs  Estimated CLI startup time (ms).  Prompt writes are delayed until
-   *                   this many ms after spawn, so the CLI is ready to process input.
-   *                   Defaults to 0 (no delay) — production code passes the env-configured value.
+   * @param poolSize       Number of processes to keep warm.
+   * @param baseArgs       Args to pass to every spawned `gemini` process (no --prompt).
+   * @param env            Restricted env for the subprocess (HOME + PATH).
+   * @param startupMs      Estimated CLI startup time (ms).  Prompt writes are delayed until
+   *                       this many ms after spawn, so the CLI is ready to process input.
+   *                       Defaults to 0 (no delay) — production code passes the env-configured value.
+   * @param binary         Path to the `gemini` binary (default: "gemini" via PATH).
+   * @param idleTimeoutMs  After this many ms with no acquire(), the pool shrinks to `minSize`.
+   *                       Defaults to 0 (eviction disabled).
+   * @param minSize        Floor the pool can shrink to during idle eviction. Must be ≤ `poolSize`.
+   *                       Defaults to 0 (full eviction when idle).
    */
   constructor(
     private readonly poolSize: number,
     private readonly baseArgs: string[],
     private readonly env: Record<string, string>,
     private readonly startupMs: number = 0,
-    private readonly binary: string = "gemini"
+    private readonly binary: string = "gemini",
+    private readonly idleTimeoutMs: number = 0,
+    private readonly minSize: number = 0
   ) {
+    if (this.minSize < 0 || this.idleTimeoutMs < 0) {
+      throw new Error("WarmProcessPool: minSize and idleTimeoutMs must be non-negative");
+    }
+    if (this.minSize > this.poolSize) {
+      throw new Error(
+        `WarmProcessPool: minSize (${this.minSize}) cannot exceed poolSize (${this.poolSize})`
+      );
+    }
     for (let i = 0; i < poolSize; i++) {
       this._spawnAndEnqueue();
+    }
+    if (this.idleTimeoutMs > 0) {
+      this.idleTimer = setInterval(() => this._evictIfIdle(), this.idleTimeoutMs);
+      // Don't keep the event loop alive solely for eviction checks — the
+      // server's other timers (job GC, session-store etc.) anchor the loop.
+      this.idleTimer.unref?.();
     }
   }
 
   /** Spawn one warm process and either give it to a waiting caller or enqueue it. */
   private _spawnAndEnqueue(): void {
-    if (this.draining) return;
+    if (this.draining || this.evicting) return;
 
     const cp = spawnInGroup(this.binary, this.baseArgs, {
       env: this.env,
@@ -176,6 +200,8 @@ export class WarmProcessPool {
       return Promise.reject(new Error("Gemini process pool is shutting down"));
     }
 
+    this.lastAcquireAt = Date.now();
+
     if (this.ready.length > 0) {
       const { wp, keepAliveInterval } = this.ready.shift()!;
       clearInterval(keepAliveInterval);
@@ -201,12 +227,56 @@ export class WarmProcessPool {
         }, timeoutMs);
       }
       this.waiters.push(waiter);
+
+      // Pool is empty (idle eviction shrank below 1, or every slot is in flight
+      // and no spawn is queued). Trigger a spawn now — `_spawnAndEnqueue`
+      // checks the waiter queue at the end of its body and hands the new
+      // process directly to the waiter we just pushed.
+      //
+      // Skip when poolSize is 0 (a deliberately empty pool, used in tests for
+      // the timeout/drain rejection paths). A zero-size pool never spawns.
+      if (!this.draining && !this.evicting && this.poolSize > 0) {
+        this._spawnAndEnqueue();
+      }
     });
+  }
+
+  /**
+   * Evict ready processes down to `minSize` if the pool has been idle for at
+   * least `idleTimeoutMs`. Called by the idle-check interval.
+   *
+   * `evicting` is set during the kill loop so the per-process `exit` listener
+   * (which would otherwise spawn a replacement at the bottom of `_spawnAndEnqueue`)
+   * stays quiet — without it the killed worker's exit event would race the
+   * eviction loop and respawn what we just killed.
+   */
+  private _evictIfIdle(): void {
+    if (this.draining) return;
+    if (Date.now() - this.lastAcquireAt < this.idleTimeoutMs) return;
+    if (this.ready.length <= this.minSize) return;
+
+    this.evicting = true;
+    try {
+      while (this.ready.length > this.minSize) {
+        const entry = this.ready.shift()!;
+        clearInterval(entry.keepAliveInterval);
+        if (entry.wp.cp.exitCode === null) {
+          killGroup(entry.wp.cp, "SIGTERM");
+        }
+      }
+    } finally {
+      this.evicting = false;
+    }
   }
 
   /** Kill all ready processes and reject all pending waiters (graceful shutdown). */
   async drain(): Promise<void> {
     this.draining = true;
+
+    if (this.idleTimer !== null) {
+      clearInterval(this.idleTimer);
+      this.idleTimer = null;
+    }
 
     // Reject all pending waiters immediately.
     for (const waiter of this.waiters) {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -83,7 +83,7 @@ beforeEach(() => {
   mockGeminiCancel.mockResolvedValue({ cancelled: true, alreadyDone: false });
   mockGeminiHealth.mockResolvedValue({
     binary: { path: "/usr/local/bin/gemini" },
-    pool: { enabled: true, ready: 1, size: 2 },
+    pool: { enabled: true, ready: 1, size: 1 },
     concurrency: { max: 2, active: 0, queued: 0 },
     jobs: { active: 0, total: 0 },
     sessions: { total: 0 },

--- a/tests/resources.test.ts
+++ b/tests/resources.test.ts
@@ -74,7 +74,7 @@ describe("readResource", () => {
     vi.clearAllMocks();
     runnerMock.getServerStats.mockReturnValue({
       semaphore: { active: 1, queued: 0 },
-      pool: { enabled: true, ready: 2, size: 2, lastError: null, consecutiveFailures: 0 },
+      pool: { enabled: true, ready: 1, size: 1, lastError: null, consecutiveFailures: 0 },
       maxConcurrent: 2,
     });
     jobStoreMock.getJobStats.mockReturnValue({

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -79,7 +79,7 @@ describe("runServerSelfTest", () => {
 
     const healthPayload = {
       binary: { path: "/usr/bin/gemini" },
-      pool: { ready: 1, size: 2 },
+      pool: { ready: 1, size: 1 },
       server: { version: "1.0.0" },
     };
     mockSelfTestSpawn(
@@ -95,7 +95,7 @@ describe("runServerSelfTest", () => {
     await expect(runServerSelfTest("/tmp/server.js", "/usr/bin/gemini")).resolves.toEqual({
       binary: "/usr/bin/gemini",
       poolReady: 1,
-      poolSize: 2,
+      poolSize: 1,
       version: "1.0.0",
     });
   });

--- a/tests/warm-pool.test.ts
+++ b/tests/warm-pool.test.ts
@@ -516,23 +516,32 @@ describe("WarmProcessPool", () => {
     const start = Date.now();
     vi.setSystemTime(start);
 
+    // idleTimeoutMs=10_000 → eviction interval ticks at start+10s, +20s, +30s.
     const pool = new WarmProcessPool(2, [], {}, 0, "gemini", 10_000, 0);
 
-    // Advance 9s — under the 10s threshold.
+    // Advance 9 s — under the threshold; no tick has fired yet.
     vi.setSystemTime(start + 9_000);
     await vi.advanceTimersByTimeAsync(9_000);
     expect(pool.readyCount).toBe(2);
 
-    // acquire() resets lastAcquireAt to "now".
+    // First reset: lastAcquireAt becomes start+9_000.
     await pool.acquire();
 
-    // Advance another 9s — total elapsed is 18s, but no contiguous 10s idle.
-    // Eviction tick at 20s (next interval) sees lastAcquireAt == start+9000,
-    // so 20000 - 9000 = 11000 ≥ 10000 → eviction would fire. We need to
-    // verify that BEFORE the next tick at start+20000 (i.e. at start+18000),
-    // no eviction has happened yet.
-    vi.setSystemTime(start + 18_000);
-    await vi.advanceTimersByTimeAsync(9_000);
+    // Cross the first interval tick at start+10_000. Inside the eviction loop,
+    // Date.now() - lastAcquireAt = 1_000 < 10_000 → no eviction. The whole
+    // point of the reset: an acquire that occurred recently buys idleTimeoutMs
+    // of fresh runway against the very next tick.
+    vi.setSystemTime(start + 15_000);
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(processKillSpy).not.toHaveBeenCalled();
+
+    // Second reset BEFORE the next tick at start+20_000. The reset is
+    // sticky-to-most-recent-acquire: at the start+20_000 tick, elapsed since
+    // this acquire is 5_000 < 10_000 → still no eviction. Without the reset
+    // the tick at +20_000 would see 20_000-9_000=11_000 and fire.
+    await pool.acquire();
+    vi.setSystemTime(start + 25_000);
+    await vi.advanceTimersByTimeAsync(10_000);
     expect(processKillSpy).not.toHaveBeenCalled();
 
     vi.useRealTimers();

--- a/tests/warm-pool.test.ts
+++ b/tests/warm-pool.test.ts
@@ -449,6 +449,149 @@ describe("WarmProcessPool", () => {
     expect(wp.readyAt).toBeGreaterThan(Date.now() + 4000);
   });
 
+  // ── idle eviction (#111) ─────────────────────────────────────────────────
+
+  it("evicts ready processes down to minSize after idleTimeoutMs", async () => {
+    vi.useFakeTimers();
+    const start = Date.now();
+    vi.setSystemTime(start);
+
+    // poolSize 3, minSize 1, idle timeout 10s
+    const pool = new WarmProcessPool(3, [], {}, 0, "gemini", 10_000, 1);
+    expect(pool.readyCount).toBe(3);
+    const initialPids = spawnCalls.slice(0, 3).map((c) => c.pid!);
+
+    // Advance past idle timeout — eviction tick fires, kills 2 of 3 processes.
+    vi.setSystemTime(start + 11_000);
+    await vi.advanceTimersByTimeAsync(11_000);
+
+    expect(pool.readyCount).toBe(1);
+    // The two evicted processes received SIGTERM via group-kill (negative pid).
+    const evictedPids = initialPids.slice(0, 2);
+    for (const pid of evictedPids) {
+      expect(processKillSpy).toHaveBeenCalledWith(-pid, "SIGTERM");
+    }
+
+    vi.useRealTimers();
+  });
+
+  it("does not evict within the idle timeout window", async () => {
+    vi.useFakeTimers();
+    const start = Date.now();
+    vi.setSystemTime(start);
+
+    const pool = new WarmProcessPool(3, [], {}, 0, "gemini", 10_000, 0);
+    expect(pool.readyCount).toBe(3);
+
+    // Advance only halfway — eviction must not fire.
+    vi.setSystemTime(start + 5_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(pool.readyCount).toBe(3);
+    expect(processKillSpy).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("does not evict when idleTimeoutMs is 0", async () => {
+    vi.useFakeTimers();
+    const start = Date.now();
+    vi.setSystemTime(start);
+
+    // idleTimeoutMs=0 disables eviction entirely.
+    const pool = new WarmProcessPool(2, [], {}, 0, "gemini", 0, 0);
+    expect(pool.readyCount).toBe(2);
+
+    vi.setSystemTime(start + 60_000);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(pool.readyCount).toBe(2);
+    expect(processKillSpy).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("acquire() resets the idle window so eviction does not fire", async () => {
+    vi.useFakeTimers();
+    const start = Date.now();
+    vi.setSystemTime(start);
+
+    const pool = new WarmProcessPool(2, [], {}, 0, "gemini", 10_000, 0);
+
+    // Advance 9s — under the 10s threshold.
+    vi.setSystemTime(start + 9_000);
+    await vi.advanceTimersByTimeAsync(9_000);
+    expect(pool.readyCount).toBe(2);
+
+    // acquire() resets lastAcquireAt to "now".
+    await pool.acquire();
+
+    // Advance another 9s — total elapsed is 18s, but no contiguous 10s idle.
+    // Eviction tick at 20s (next interval) sees lastAcquireAt == start+9000,
+    // so 20000 - 9000 = 11000 ≥ 10000 → eviction would fire. We need to
+    // verify that BEFORE the next tick at start+20000 (i.e. at start+18000),
+    // no eviction has happened yet.
+    vi.setSystemTime(start + 18_000);
+    await vi.advanceTimersByTimeAsync(9_000);
+    expect(processKillSpy).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("spawns a fresh process for waiters when the pool was emptied by eviction", async () => {
+    vi.useFakeTimers();
+    const start = Date.now();
+    vi.setSystemTime(start);
+
+    const pool = new WarmProcessPool(2, [], {}, 0, "gemini", 5_000, 0);
+    const initialSpawnCount = spawnCalls.length;
+    expect(initialSpawnCount).toBe(2);
+
+    // Drain the pool via idle eviction.
+    vi.setSystemTime(start + 6_000);
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(pool.readyCount).toBe(0);
+
+    // acquire() on an empty pool must trigger a fresh spawn that resolves the waiter.
+    const acquirePromise = pool.acquire();
+    // The synchronous body of acquire pushed a waiter and triggered a spawn;
+    // _spawnAndEnqueue's post-spawn handoff resolves the waiter immediately.
+    const wp = await acquirePromise;
+    expect(wp).toBeDefined();
+    expect(spawnCalls.length).toBeGreaterThan(initialSpawnCount);
+
+    vi.useRealTimers();
+  });
+
+  it("drain() clears the idle eviction timer (no leaks)", async () => {
+    vi.useFakeTimers();
+    const start = Date.now();
+    vi.setSystemTime(start);
+
+    const pool = new WarmProcessPool(2, [], {}, 0, "gemini", 10_000, 0);
+    await pool.drain();
+    processKillSpy?.mockClear();
+
+    // After drain, advance well past what would have triggered eviction —
+    // no further process.kill calls (interval was cleared).
+    vi.setSystemTime(start + 60_000);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(processKillSpy).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("constructor rejects minSize > poolSize", () => {
+    expect(() => new WarmProcessPool(2, [], {}, 0, "gemini", 1_000, 5)).toThrow(
+      /minSize.*cannot exceed poolSize/i
+    );
+  });
+
+  it("constructor rejects negative idleTimeoutMs or minSize", () => {
+    expect(() => new WarmProcessPool(2, [], {}, 0, "gemini", -1, 0)).toThrow();
+    expect(() => new WarmProcessPool(2, [], {}, 0, "gemini", 0, -1)).toThrow();
+  });
+
   // ── concurrent waiters ────────────────────────────────────────────────────
 
   // Note: this tests sequential acquire() ordering (ready-queue FIFO), not


### PR DESCRIPTION
## Summary

Bounds `gemini-cli-mcp`'s per-instance warm-pool footprint so multi-window / multi-session workflows stop holding several GB of idle RAM:

- **Default `GEMINI_POOL_SIZE`: 2 → 1.** One warm slot per server, sized for the multi-instance common case. Validation tightened to throw on invalid input, matching the `GEMINI_MAX_CONCURRENT` pattern.
- **Idle eviction.** New `GEMINI_POOL_IDLE_TIMEOUT_MS` (default 300000 = 5 min, `0` disables) and `GEMINI_POOL_MIN_SIZE` (default 0) shrink the pool after inactivity. Killed via the existing `process-group.killGroup` path; eviction interval is `unref`'d.

Together: developers with many editors open pay near-zero idle cost, while heavy users can opt into larger pools knowing the cost relaxes during quiet windows.

## Why

Each MCP client (each Claude Code window, each Codex CLI session, each editor) spawns its own `gemini-cli-mcp` child via stdio transport — pools never share. Empirical snapshot from the maintainer's box: **~13 MCP server processes × pool size 2 ≈ 14 idle warm workers, ~3–5 GB RAM**. Cross-instance sharing (HTTP singleton, daemon) was considered and deferred — see research doc.

Bundles #110 (lower default) + #111 (idle eviction) per the design decision in the linked research doc — the docs touch the same files and the two phases are intrinsically coupled (the README "Per-instance cost" section discusses both env vars together).

## Implementation notes

- `acquire()` on an empty pool now triggers a fresh spawn for the queued waiter. Required so post-eviction acquires resolve instead of hanging. Gated on `poolSize > 0` to preserve existing zero-size pool semantics used in timeout/drain rejection tests.
- `evicting` flag prevents the per-process `exit` handler's respawn branch from immediately re-spawning what idle eviction just killed.
- `drain()` clears the new eviction interval to prevent timer leaks across server restarts in tests.

## Test plan

### Unit

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 660/660 pass (29 existing warm-pool tests + 8 new eviction tests)
- [x] `node scripts/verify-pool-logic.mjs` — exit 0
- [x] `npm run build` — clean

### Hands-on integration (against local `dist/index.js` via the `gemini-dev` MCP server)

- [x] (1) `ask-gemini` basic prompt with `wait: true` — round-tripped `"scenario-1-ok"`
- [x] (2) `gemini-reply` continuing a session — recalled the prior turn's phrase verbatim (session-store round-trip)
- [x] (3) Async `ask-gemini` (no `wait`) + `gemini-poll` — completed job poll returns cached result with `status: "done"`
- [x] (4) `gemini-cancel` lifecycle — long prompt cancelled mid-flight, post-cancel poll returns `status: "cancelled"`
- [x] (5) `@file` reference expansion — read `src/warm-pool.ts` and correctly extracted `KEEPALIVE_INTERVAL_MS = 5000`
- [x] (6) Two concurrent `ask-gemini` calls — both succeeded with distinct sessions; semaphore still allows 2 concurrent (the accepted cold-spawn trade-off for the 2nd)
- [x] (7) **Idle eviction end-to-end** — server launched with `GEMINI_POOL_SIZE=2 GEMINI_POOL_IDLE_TIMEOUT_MS=15000 GEMINI_POOL_MIN_SIZE=0`. Observed via `pgrep -P <server>`:
  - t=3 s: 2 worker children ✅ (env vars wired)
  - t=21 s: 0 children ✅ (eviction loop fires + `killGroup` propagates SIGTERM to worker group)
  - t=24 s (3 s after MCP `tools/call`): 2 children (1 in-flight for prompt + 1 post-handoff replenishment) ✅
  - t=29 s: 1 child (replenishment slot remains in `ready`) ✅
  - 2nd request within 15 s window: warm-hit pattern observed (existing replenishment acquired, fresh replacement spawned) ✅
  - SIGTERM to server: clean drain, zero orphan workers ✅

### Review fixes (PR feedback round)

Six follow-up fixes from the parallel-review pass (commit `f9cb253`):

- [x] `getEnvOverrides()` POOL_SIZE sentinel corrected (was `MAX_CONCURRENT=2`, now reflects new default `1`); added `IDLE_TIMEOUT_MS` / `MIN_SIZE` overrides — smoke: `node -e "import('./dist/gemini-runner.js').then(m=>console.log(JSON.stringify(m.getEnvOverrides())))"` returns `{}` at default, `{"GEMINI_POOL_SIZE":2,"GEMINI_POOL_IDLE_TIMEOUT_MS":60000,"GEMINI_POOL_MIN_SIZE":1}` with overrides
- [x] `_evictIfIdle` JSDoc rewritten to credit splice-before-kill as the primary respawn defense (the `evicting` flag's actual job is gating `acquire()`'s post-eviction spawn at line 238) — three reviewers converged on this; doc now matches the code
- [x] "acquire() resets idle window" test restructured to actually prove the contract — chains two acquires across two interval ticks, where the previous version stopped before the post-acquire boundary; full suite still 660/660
- [x] `mcpLog("info","pool",{event:"idle_eviction",evicted,remaining,idleMs})` emitted from `_evictIfIdle` so the cost-control feature is visible to `GEMINI_STRUCTURED_LOGS=1` monitoring (was silent before — operators only had `pgrep` to verify)
- [x] Pool env-var validation gated behind `if (POOL_ENABLED)` — smoke: `GEMINI_POOL_ENABLED=0 GEMINI_POOL_SIZE=invalid GEMINI_POOL_IDLE_TIMEOUT_MS=garbage GEMINI_POOL_MIN_SIZE=-99 node -e "import('./dist/gemini-runner.js').then(m=>console.log(m.warmPool===null?'null':'CREATED'))"` prints `null` (no crash); with `POOL_ENABLED=1`, `POOL_SIZE=invalid` still throws as expected
- [x] Research doc line 69 marked as pre-PR snapshot with merged-state callout so future readers don't see contradictory defaults

Skipped (10 findings, see triage in conversation): counter-recommendation to raise `POOL_SIZE` default (counter to PR intent); pool overshoot under burst empty-pool acquires (bounded by `MAX_CONCURRENT=2`, follow-up issue material); `POOL_STARTUP_MS`/`QUEUE_TIMEOUT_MS` validation gaps (pre-existing, out of scope); module-load throw discoverability via MCP (architectural); research-doc line numbers (historical snapshot); `unref?.()` paranoid chain (harmless); minor coverage suggestions; false-positive "test resource leak" (real timers + `vi.useRealTimers()` in `afterEach` cancels the unref'd intervals).

## Research

Full investigation: `docs/research/2026-05-09-warm-pool-per-instance-cost.md`

Closes #110
Closes #111
