### PR TITLE
chore(release-please): keep 0.x in minor bumps via bump-minor-pre-major

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "bump-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

- Add `bump-minor-pre-major: true` to `release-please-config.json` so BREAKING CHANGE footers produce a minor bump (e.g. `0.9.0 -> 0.10.0`) while the project is still in 0.x, instead of promoting to 1.0.0.
- Leave `bump-patch-for-minor-pre-major` off so `feat:` commits keep producing minor bumps — matching the pattern across 0.5.x -> 0.6.0 -> 0.7.0 -> 0.8.0.

## Why

Release-please opened PR #123 proposing `0.9.0 -> 1.0.0` because the PR #118 merge commit body preserved a `feat!: remove deprecated parseGeminiOutput + GeminiJsonOutput exports` sub-commit with a `BREAKING CHANGE:` footer. The removal is semver-breaking but the symbols were `@deprecated` with zero in-tree consumers — not a 1.0 moment.

## Test plan

### Impact coverage audit
- [x] **All files in the diff have been reviewed for points of impact** — only `release-please-config.json` changed; consumed by `googleapis/release-please-action@v4` in `.github/workflows/release-please.yml` (the only file that references release-please).
- [x] **Every identified impact point has a corresponding test scenario below** — JSON validity + post-merge release-please behavior are both covered.
- [x] Uncovered areas: _None._

### Documentation

- [x] **README / user-facing docs** — _Not affected: this is internal release-tooling config; users do not interact with release-please configuration._
- [x] **API docs (OpenAPI, JSDoc, etc.)** — _Not affected: no code surface changes._
- [x] **Inline code comments** — _Not affected: no source files changed._
- [x] **CHANGELOG / migration guide** — _Not affected: this PR uses `chore:` which is hidden from the changelog. The change is invisible to consumers; only the version number on the *next* release will reflect it._
- [x] **LLM / AI docs (`CLAUDE.md`, `AGENTS.md`)** — _Reviewed `AGENTS.md` "Commit conventions (release-please)" section. The existing wording already requires `feat!:` / `BREAKING CHANGE:` for public-surface removals and does not contradict `bump-minor-pre-major: true` (which controls the *resulting* version, not the footer requirement). No change needed._
- [x] **Architecture Decision Records** — _Not affected: no ADR directory in repo; the rationale lives in this PR description and the commit body._
- [x] **Runbooks / ops docs** — _Not affected: no runbooks in repo._
- [x] **Contributing / dev setup** — _Not affected: contributor workflow unchanged; Conventional Commits requirement is the same._
- [x] **Security docs** — _Not affected: no security surface touched._
- [x] **Environment / infra docs (`.env.example`, etc.)** — _Not affected: no env vars or infra config changed._
- [x] **Component / design system docs** — _Not affected: no UI in this repo._
- [x] **Error catalog / troubleshooting** — _Not affected: no error surface changes._

### Functional scenarios

- [x] **Scenario: JSON config is syntactically valid**
  **Method:** CLI — _No UI surface; this is a build-tool config file._
  **Steps:**
  1. `jq -e . release-please-config.json`
  - [x] **Expected:** Exit 0, file parses as valid JSON. ✅ Verified locally before commit.

- [x] **Scenario: CI passes on the change**
  **Method:** CLI (GitHub Actions) — _Build-tool config has no runtime UI; CI's build/lint/test confirms the JSON does not break the tsc/eslint/vitest pipeline._
  **Steps:**
  1. Mark PR ready for review to un-skip the `Build & Lint & Test` matrix job.
  2. Wait for the workflow to complete.
  - [x] **Expected:** All matrix jobs green. ✅ Verified via `gh pr checks 125`.

### Post-merge observation (not a pre-merge checkbox)

After this merges, the next Release Please workflow run on `main` should update or replace PR #123 with a proposal for version `0.10.0` (not `1.0.0`). If that does not happen within ~2 minutes of the merge, the config flag name should be re-verified against the release-please-action docs and the workflow logs inspected.